### PR TITLE
Update docs and launcher version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-		  # CHANGELOG
+# CHANGELOG
+
+## v25.0.0 (2025-06-26)
+- Updated docs and launcher script to sync version numbers with code base.
 
 ## v24.0.1 (2024-06-20)
 - Refactored to fully modular, maintainable codebase with clear separation of GUI, OCR, AI extraction, file handling, and Excel output.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KYO QA ServiceNow Knowledge Tool v24.0.1
+# KYO QA ServiceNow Knowledge Tool v25.0.0
 
 ## How to Set Up and Run (Modular, Fully Logged)
 
@@ -8,7 +8,7 @@
 - **Optional:** All dependencies listed in `requirements.txt` (auto-installed if you run `start_tool.py`)
 
 ### 2. Folder Structure
-KYO_QA_ServiceNow_Knowledge_Tool_v24.0.1/
+KYO_QA_ServiceNow_Knowledge_Tool_v25.0.0/
 ├── run_tool.bat
 ├── start_tool.py
 ├── requirements.txt
@@ -26,7 +26,7 @@ KYO_QA_ServiceNow_Knowledge_Tool_v24.0.1/
 ├── logs/(auto-created)
 ├── output/(auto-created)
 └── venv/(auto-created)
-# KYO QA ServiceNow Knowledge Tool v24.0.1 – Directory Breakdown
+# KYO QA ServiceNow Knowledge Tool v25.0.0 – Directory Breakdown
 
 This tool extracts model info, QA/SB numbers, and descriptions from Kyocera QA/service PDFs using OCR + pattern recognition. It outputs a ServiceNow-ready Excel file and logs every step. No PDFs are retained.
 
@@ -99,7 +99,7 @@ If you plan to run or test the tool locally, first install the required Python
 packages with the helper script:
 
 ```bash
-cd KYO_QA_ServiceNow_Knowledge_Tool_v24.0.1
+cd KYO_QA_ServiceNow_Knowledge_Tool_v25.0.0
 ./scripts/setup_env.sh
 ```
 
@@ -115,11 +115,11 @@ pytest -q
 
 The tests rely on `pandas`, `PyMuPDF`, and the rest of the packages listed in
 `requirements.txt`. If `PyMuPDF` is missing you will see import errors. As of
-v24.0.1, unused packages `xlsxwriter` and `halo` were removed to keep the
+v25.0.0, unused packages `xlsxwriter` and `halo` were removed to keep the
 environment lean.
 
 ### 4. Versioning
-- This is the modular, logging-enabled release: **v24.0.1**
+- This is the modular, logging-enabled release: **v25.0.0**
 - Each file and log is stamped with its version.
 - All updates are tracked in `CHANGELOG.md`.
 

--- a/run.py
+++ b/run.py
@@ -1,8 +1,8 @@
-# KYO QA ServiceNow Tool - Python Package Installer v24.0.6
+# KYO QA ServiceNow Tool - Python Package Installer v25.0.0
 import sys, subprocess, importlib.metadata
 
 try: from version import VERSION
-except ImportError: VERSION = "24.0.6"
+except ImportError: VERSION = "25.0.0"
 
 # FIXED: Added 'ollama' to ensure the AI component can run.
 REQUIRED_PACKAGES = ["pandas", "openpyxl", "PyMuPDF", "pytesseract", "ollama"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import version
+
+def test_version():
+    assert version.VERSION == "25.0.0"


### PR DESCRIPTION
## Summary
- sync docs with v25.0.0
- bump run.py version
- add simple unit test for version value

## Testing
- `ruff check run.py start_tool.py version.py`
- `pytest -q tests/test_version.py`

------
https://chatgpt.com/codex/tasks/task_e_685cda7bb60c832e8813ddc05ff2bae5