### PR TITLE
Update version docs to v25.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v25.0.0 (2025-06-26)
+- Updated docs and internal references to version 25.0.0.
+- Adjusted installer fallback version to ensure banner matches.
+
 ## v25.0.0 (2024-06-20)
 - Version bump for documentation refresh and minor improvements.
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import run
+
+def test_run_version_constant():
+    assert run.VERSION == "25.0.0"

--- a/update_version.py
+++ b/update_version.py
@@ -99,7 +99,7 @@ def update_version(old_version, new_version):
 if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("Usage: python update_version.py old_version new_version")
-        print("Example: python update_version.py v24.0.1 v24.0.2")
+        print("Example: python update_version.py v25.0.0 v25.0.1")
         sys.exit(1)
         
     old_version = sys.argv[1]
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     # Validate version format
     if not re.match(r'^v\d+\.\d+\.\d+$', old_version) or not re.match(r'^v\d+\.\d+\.\d+$', new_version):
         print("Error: Version numbers must be in the format vYY.Minor.Patch")
-        print("Example: v24.0.1")
+        print("Example: v25.0.0")
         sys.exit(1)
         
     update_version(old_version, new_version)


### PR DESCRIPTION
## Summary
- document new v25.0.0 release in CHANGELOG
- update version helper examples
- test run.VERSION constant

## Testing
- `ruff check .` *(fails: multiple style violations)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cdcada310832e99325a2cd40371a6