### PR TITLE
Replace run_tool.bat reference

### DIFF
--- a/tests/test_update_version.py
+++ b/tests/test_update_version.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from update_version import FILES_TO_UPDATE
+
+
+def test_files_list_includes_start_bat():
+    assert "START.bat" in FILES_TO_UPDATE
+    assert "run_tool.bat" not in FILES_TO_UPDATE
+

--- a/update_version.py
+++ b/update_version.py
@@ -6,26 +6,26 @@ import re
 from datetime import datetime
 import sys
 
-def update_version(old_version, new_version):
+# Files that should have the version string updated
+FILES_TO_UPDATE = [
+    "version.py",
+    "ai_extractor.py",
+    "custom_exceptions.py",
+    "data_harvesters.py",
+    "excel_generator.py",
+    "file_utils.py",
+    "kyo_qa_tool_app.py",
+    "logging_utils.py",
+    "ocr_utils.py",
+    "processing_engine.py",
+    "README.md",
+    "start_tool.py",
+    "START.bat",
+]
+
+def update_version(old_version, new_version, files_to_update=FILES_TO_UPDATE):
     """Update the version number in all files."""
     print(f"Updating version from {old_version} to {new_version}")
-    
-    # List of files to update
-    files_to_update = [
-        "version.py",
-        "ai_extractor.py",
-        "custom_exceptions.py",
-        "data_harvesters.py",
-        "excel_generator.py",
-        "file_utils.py",
-        "kyo_qa_tool_app.py",
-        "logging_utils.py",
-        "ocr_utils.py",
-        "processing_engine.py",
-        "README.md",
-        "start_tool.py",
-        "run_tool.bat"
-    ]
     
     # Regular expressions for updating different file types
     version_patterns = {


### PR DESCRIPTION
## Summary
- centralize `FILES_TO_UPDATE` list in `update_version.py`
- swap `run_tool.bat` with `START.bat`
- add regression test for the files list

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cdcb7fe24832e853fbcf3d46805d9