### PR TITLE
Add service mapping tests

### DIFF
--- a/processing_engine.py
+++ b/processing_engine.py
@@ -105,6 +105,21 @@ def _is_ocr_needed(pdf_path):
         return True
 
 def map_to_servicenow_format(extracted_data, filename):
-    # This function is complete and correct from previous versions
-    # ... (code for this function remains the same)
-    pass
+    """Map raw extracted fields to the ServiceNow Excel headers."""
+
+    record = {}
+    for src_key, header in HEADER_MAPPING.items():
+        if src_key == "file_name":
+            record[header] = filename
+        else:
+            record[header] = extracted_data.get(src_key, "")
+
+    if not record.get(HEADER_MAPPING["author"]):
+        record[HEADER_MAPPING["author"]] = STANDARDIZATION_RULES["default_author"]
+
+    if not record.get(HEADER_MAPPING["processing_status"]):
+        record[HEADER_MAPPING["processing_status"]] = (
+            "Needs Review" if extracted_data.get("needs_review") else "Success"
+        )
+
+    return record

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from processing_engine import map_to_servicenow_format
+from config import HEADER_MAPPING
+from excel_generator import ExcelWriter
+from openpyxl import load_workbook
+
+
+def test_map_to_servicenow_format_keys():
+    sample = {
+        "author": "Jane",
+        "short_description": "Example",
+        "models": "Model A",
+    }
+    result = map_to_servicenow_format(sample, "file.pdf")
+    assert set(HEADER_MAPPING.values()).issubset(result.keys())
+    assert result[HEADER_MAPPING["file_name"]] == "file.pdf"
+    assert result[HEADER_MAPPING["author"]] == "Jane"
+
+
+def test_excel_writer_save_creates_file(tmp_path):
+    filepath = tmp_path / "out.xlsx"
+    headers = ["Col1", "Col2"]
+    writer = ExcelWriter(filepath, headers)
+    writer.add_row({"Col1": "A", "Col2": "B"})
+    writer.save()
+    assert filepath.exists()
+    wb = load_workbook(filepath)
+    sheet = wb.active
+    assert sheet["A1"].font.bold


### PR DESCRIPTION
## Summary
- implement `map_to_servicenow_format`
- add tests verifying header mapping and Excel output

## Testing
- `ruff check tests/test_mapping.py processing_engine.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685cdcba7370832eaca317189be4afdb