### PR TITLE
Add GUI log handler

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -82,6 +82,8 @@ class MainWindow(QMainWindow):
         self.result_file_path = None
         self._setup_window_and_widgets()
         self.setStyleSheet(STYLESHEET)
+        # Register GUI log handler now that the text edit widget exists
+        setup_logger("app_ui", log_widget=self.log_text_edit)
 
     def _setup_window_and_widgets(self):
         self.setWindowTitle(f"Kyocera QA ServiceNow Knowledge Tool v{VERSION}")

--- a/tests/test_logging_gui.py
+++ b/tests/test_logging_gui.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import logging
+from logging_utils import setup_logger, QtWidgetHandler
+
+class DummyTextEdit:
+    def __init__(self):
+        self.messages = []
+    def append(self, msg):
+        self.messages.append(msg)
+
+def test_gui_handler_appends_messages():
+    widget = DummyTextEdit()
+    logger = setup_logger('gui_test', log_widget=widget)
+    logger.setLevel(logging.INFO)
+    logger.info('hello world')
+    assert any('hello world' in m for m in widget.messages)


### PR DESCRIPTION
## Summary
- send log output to the GUI with new `QtWidgetHandler`
- register GUI handler after the main window creates its log box
- test that `QtWidgetHandler` appends to a dummy text widget

## Testing
- `python -m py_compile logging_utils.py kyo_qa_tool_app.py tests/test_logging_gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce574fe94832ea290b8f13546f228