### PR TITLE
Add callback hooks for processing events

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -66,7 +66,17 @@ class ProcessingWorker(QThread):
         try:
             path_obj = Path(self.process_path)
             process_func = process_folder if path_obj.is_dir() else process_zip_archive
-            updated_path, updated, failed = process_func(self.process_path, self.kb_path, self.progress_updated.emit, self.status_updated.emit, lambda: None, self.cancel_event)
+            updated_path, updated, failed = process_func(
+                self.process_path,
+                self.kb_path,
+                self.progress_updated.emit,
+                self.status_updated.emit,
+                self.ocr_used_signal.emit,
+                self.cancel_event,
+                success_cb=self.file_succeeded.emit,
+                failure_cb=self.file_failed.emit,
+                needs_review_cb=self.needs_review_signal.emit,
+            )
             self.processing_finished.emit(updated_path, updated, failed)
         except Exception as e:
             logger.error("Error in worker thread", exc_info=True)

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -15,12 +15,42 @@ from config import STANDARDIZATION_RULES, HEADER_MAPPING
 
 logger = setup_logger("processing_engine")
 
-def process_folder(folder_path, kb_filepath, progress_cb, status_cb, ocr_cb, cancel_event):
+def process_folder(
+    folder_path,
+    kb_filepath,
+    progress_cb,
+    status_cb,
+    ocr_cb,
+    cancel_event,
+    success_cb=None,
+    failure_cb=None,
+    needs_review_cb=None,
+):
     log_info(logger, f"Starting to process FOLDER: {folder_path}")
     files_to_process = [p for p in Path(folder_path).iterdir() if p.suffix.lower() in ['.pdf', '.zip']]
-    return _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb, cancel_event)
+    return _main_processing_loop(
+        files_to_process,
+        kb_filepath,
+        progress_cb,
+        status_cb,
+        cancel_event,
+        success_cb=success_cb,
+        failure_cb=failure_cb,
+        needs_review_cb=needs_review_cb,
+        ocr_cb=ocr_cb,
+    )
 
-def process_zip_archive(zip_path, kb_filepath, progress_cb, status_cb, ocr_cb, cancel_event):
+def process_zip_archive(
+    zip_path,
+    kb_filepath,
+    progress_cb,
+    status_cb,
+    ocr_cb,
+    cancel_event,
+    success_cb=None,
+    failure_cb=None,
+    needs_review_cb=None,
+):
     log_info(logger, f"Starting to process ZIP: {zip_path}")
     temp_dir = get_temp_dir()
     try:
@@ -29,11 +59,31 @@ def process_zip_archive(zip_path, kb_filepath, progress_cb, status_cb, ocr_cb, c
             if not pdf_names: return kb_filepath, 0, 0
             zip_ref.extractall(temp_dir, members=pdf_names)
             files_to_process = [temp_dir / name for name in pdf_names]
-            return _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb, cancel_event)
+            return _main_processing_loop(
+                files_to_process,
+                kb_filepath,
+                progress_cb,
+                status_cb,
+                cancel_event,
+                success_cb=success_cb,
+                failure_cb=failure_cb,
+                needs_review_cb=needs_review_cb,
+                ocr_cb=ocr_cb,
+            )
     finally:
         cleanup_temp_files(temp_dir)
 
-def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb, cancel_event):
+def _main_processing_loop(
+    files_to_process,
+    kb_filepath,
+    progress_cb,
+    status_cb,
+    cancel_event,
+    success_cb=None,
+    failure_cb=None,
+    needs_review_cb=None,
+    ocr_cb=None,
+):
     if is_file_locked(Path(kb_filepath)):
         raise FileLockError(f"Knowledge Base file is locked: {kb_filepath}")
     
@@ -57,12 +107,16 @@ def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb,
             
             if _is_ocr_needed(file_path):
                 status_cb("OCR", f"Performing OCR on {file_path.name}...")
+                if ocr_cb:
+                    ocr_cb()
             
             text = extract_text_from_pdf(file_path)
             if not text:
                 log_warning(logger, f"No text extracted from {file_path.name}. Marking as failure.")
                 status_cb("FAIL", f"Failed: Could not extract text from {file_path.name}")
                 failed_count += 1
+                if failure_cb:
+                    failure_cb()
                 continue
 
             status_cb("AI", f"Analyzing content of {file_path.name}...")
@@ -70,6 +124,8 @@ def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb,
             
             if extracted_data.get("needs_review"):
                 status_cb("NEEDS_REVIEW", f"{file_path.name} flagged for manual review.")
+                if needs_review_cb:
+                    needs_review_cb()
             else:
                 status_cb("SUCCESS", f"Successfully extracted data from {file_path.name}.")
 
@@ -82,11 +138,15 @@ def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb,
                     elif header_name == 'Author' and value != STANDARDIZATION_RULES['default_author']:
                         df.at[row_index, header_name] = value
             updated_count += 1
+            if success_cb:
+                success_cb()
         except Exception as e:
             log_error(logger, f"Failed to process {file_path.name}: {e}")
             # --- FIX 2: Provide two arguments to the status callback ---
             status_cb("FAIL", f"Critical error on {file_path.name}")
             failed_count += 1
+            if failure_cb:
+                failure_cb()
     
     if updated_count > 0:
         df.to_excel(kb_filepath, index=False, engine='openpyxl')

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,117 @@
+import sys
+import types
+from pathlib import Path
+import threading
+
+# Ensure repository root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub external dependencies used by processing_engine
+for mod in ("fitz",):
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+
+if "dateutil" not in sys.modules:
+    dateutil = types.ModuleType("dateutil")
+    sys.modules["dateutil"] = dateutil
+if "dateutil.relativedelta" not in sys.modules:
+    rd = types.ModuleType("dateutil.relativedelta")
+    class _RD:
+        def __init__(self, **kw):
+            pass
+    rd.relativedelta = _RD
+    sys.modules["dateutil.relativedelta"] = rd
+
+
+class FakeColumn(list):
+    def __eq__(self, other):
+        return [v == other for v in self]
+
+
+class FakeIndex(list):
+    def __getitem__(self, item):
+        if isinstance(item, list):
+            return FakeIndex([idx for idx, flag in zip(self, item) if flag])
+        return super().__getitem__(item)
+
+    def tolist(self):
+        return list(self)
+
+
+class FakeAtAccessor:
+    def __init__(self, df):
+        self.df = df
+
+    def __getitem__(self, key):
+        row, col = key
+        return self.df._data[col][row]
+
+    def __setitem__(self, key, value):
+        row, col = key
+        self.df._data[col][row] = value
+
+
+class FakeDF:
+    def __init__(self):
+        self._data = {"Description": ["file1.pdf"], "Author": [""]}
+        self.columns = list(self._data.keys())
+        self._index = FakeIndex([0])
+        self.at = FakeAtAccessor(self)
+
+    def __getitem__(self, key):
+        return FakeColumn(self._data[key])
+
+    @property
+    def index(self):
+        return self._index
+
+    def to_excel(self, *a, **k):
+        pass
+
+
+def isna(value):
+    return value in (None, "")
+
+pd_stub_module = types.ModuleType("pandas")
+pd_stub_module.read_excel = lambda *a, **k: FakeDF()
+pd_stub_module.isna = isna
+sys.modules.setdefault("pandas", pd_stub_module)
+
+import processing_engine
+
+
+def test_main_loop_triggers_callbacks(monkeypatch):
+    callbacks = {"success": 0, "fail": 0, "review": 0, "ocr": 0}
+
+    pd_stub = types.SimpleNamespace(read_excel=lambda *a, **k: FakeDF(), isna=isna)
+    monkeypatch.setattr(processing_engine, "pd", pd_stub)
+    monkeypatch.setattr(processing_engine, "_is_ocr_needed", lambda p: True)
+    monkeypatch.setattr(processing_engine, "extract_text_from_pdf", lambda p: "text")
+    monkeypatch.setattr(processing_engine, "ai_extract", lambda t, p: {"needs_review": True})
+    monkeypatch.setattr(processing_engine, "map_to_servicenow_format", lambda d, n: {"Author": "A", "Description": n})
+
+    def success():
+        callbacks["success"] += 1
+
+    def fail():
+        callbacks["fail"] += 1
+
+    def review():
+        callbacks["review"] += 1
+
+    def ocr():
+        callbacks["ocr"] += 1
+
+    processing_engine._main_processing_loop(
+        [Path("file1.pdf")],
+        "dummy.xlsx",
+        lambda x: None,
+        lambda *a: None,
+        threading.Event(),
+        success_cb=success,
+        failure_cb=fail,
+        needs_review_cb=review,
+        ocr_cb=ocr,
+    )
+
+    assert callbacks == {"success": 1, "fail": 0, "review": 1, "ocr": 1}


### PR DESCRIPTION
## Summary
- extend processing engine loop to accept optional callbacks
- fire callbacks when OCR used, success, failure, or needs-review
- pass Qt signals from `ProcessingWorker` to processing functions
- add tests covering callback invocation

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce2222c58832e92574557b195b7f9