### PR TITLE
Add UI callback hooks to processing pipeline

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -66,7 +66,17 @@ class ProcessingWorker(QThread):
         try:
             path_obj = Path(self.process_path)
             process_func = process_folder if path_obj.is_dir() else process_zip_archive
-            updated_path, updated, failed = process_func(self.process_path, self.kb_path, self.progress_updated.emit, self.status_updated.emit, lambda: None, self.cancel_event)
+            updated_path, updated, failed = process_func(
+                self.process_path,
+                self.kb_path,
+                self.progress_updated.emit,
+                self.status_updated.emit,
+                self.file_succeeded.emit,
+                self.file_failed.emit,
+                self.needs_review_signal.emit,
+                self.ocr_used_signal.emit,
+                self.cancel_event,
+            )
             self.processing_finished.emit(updated_path, updated, failed)
         except Exception as e:
             logger.error("Error in worker thread", exc_info=True)

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -15,12 +15,42 @@ from config import STANDARDIZATION_RULES, HEADER_MAPPING
 
 logger = setup_logger("processing_engine")
 
-def process_folder(folder_path, kb_filepath, progress_cb, status_cb, ocr_cb, cancel_event):
+def process_folder(
+    folder_path,
+    kb_filepath,
+    progress_cb,
+    status_cb,
+    file_succeeded_cb=lambda: None,
+    file_failed_cb=lambda: None,
+    needs_review_cb=lambda: None,
+    ocr_used_cb=lambda: None,
+    cancel_event=None,
+):
     log_info(logger, f"Starting to process FOLDER: {folder_path}")
     files_to_process = [p for p in Path(folder_path).iterdir() if p.suffix.lower() in ['.pdf', '.zip']]
-    return _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb, cancel_event)
+    return _main_processing_loop(
+        files_to_process,
+        kb_filepath,
+        progress_cb,
+        status_cb,
+        file_succeeded_cb,
+        file_failed_cb,
+        needs_review_cb,
+        ocr_used_cb,
+        cancel_event,
+    )
 
-def process_zip_archive(zip_path, kb_filepath, progress_cb, status_cb, ocr_cb, cancel_event):
+def process_zip_archive(
+    zip_path,
+    kb_filepath,
+    progress_cb,
+    status_cb,
+    file_succeeded_cb=lambda: None,
+    file_failed_cb=lambda: None,
+    needs_review_cb=lambda: None,
+    ocr_used_cb=lambda: None,
+    cancel_event=None,
+):
     log_info(logger, f"Starting to process ZIP: {zip_path}")
     temp_dir = get_temp_dir()
     try:
@@ -29,11 +59,31 @@ def process_zip_archive(zip_path, kb_filepath, progress_cb, status_cb, ocr_cb, c
             if not pdf_names: return kb_filepath, 0, 0
             zip_ref.extractall(temp_dir, members=pdf_names)
             files_to_process = [temp_dir / name for name in pdf_names]
-            return _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb, cancel_event)
+            return _main_processing_loop(
+                files_to_process,
+                kb_filepath,
+                progress_cb,
+                status_cb,
+                file_succeeded_cb,
+                file_failed_cb,
+                needs_review_cb,
+                ocr_used_cb,
+                cancel_event,
+            )
     finally:
         cleanup_temp_files(temp_dir)
 
-def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb, cancel_event):
+def _main_processing_loop(
+    files_to_process,
+    kb_filepath,
+    progress_cb,
+    status_cb,
+    file_succeeded_cb,
+    file_failed_cb,
+    needs_review_cb,
+    ocr_used_cb,
+    cancel_event,
+):
     if is_file_locked(Path(kb_filepath)):
         raise FileLockError(f"Knowledge Base file is locked: {kb_filepath}")
     
@@ -57,11 +107,13 @@ def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb,
             
             if _is_ocr_needed(file_path):
                 status_cb("OCR", f"Performing OCR on {file_path.name}...")
+                ocr_used_cb()
             
             text = extract_text_from_pdf(file_path)
             if not text:
                 log_warning(logger, f"No text extracted from {file_path.name}. Marking as failure.")
                 status_cb("FAIL", f"Failed: Could not extract text from {file_path.name}")
+                file_failed_cb()
                 failed_count += 1
                 continue
 
@@ -70,8 +122,10 @@ def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb,
             
             if extracted_data.get("needs_review"):
                 status_cb("NEEDS_REVIEW", f"{file_path.name} flagged for manual review.")
+                needs_review_cb()
             else:
                 status_cb("SUCCESS", f"Successfully extracted data from {file_path.name}.")
+            file_succeeded_cb()
 
             row_index = target_rows[0]
             formatted_record = map_to_servicenow_format(extracted_data, file_path.name)
@@ -86,6 +140,7 @@ def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb,
             log_error(logger, f"Failed to process {file_path.name}: {e}")
             # --- FIX 2: Provide two arguments to the status callback ---
             status_cb("FAIL", f"Critical error on {file_path.name}")
+            file_failed_cb()
             failed_count += 1
     
     if updated_count > 0:

--- a/tests/test_processing_callbacks.py
+++ b/tests/test_processing_callbacks.py
@@ -1,0 +1,136 @@
+import sys
+import types
+from pathlib import Path
+import threading
+
+# Ensure repo root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import processing_engine
+
+class DummyDF:
+    def __init__(self, rows):
+        self.rows = rows
+        self.columns = list(rows[0].keys())
+        self.at = _DummyAt(rows)
+
+    def __getitem__(self, key):
+        return _Series([row[key] for row in self.rows])
+
+    @property
+    def index(self):
+        return _DummyIndex(len(self.rows))
+
+    def to_excel(self, *a, **k):
+        pass
+
+class _DummyIndex:
+    def __init__(self, length):
+        self.length = length
+
+    def __getitem__(self, cond):
+        return _IndexResult([i for i, c in enumerate(cond) if c])
+
+    def tolist(self):
+        return list(range(self.length))
+
+class _DummyAt:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def __getitem__(self, key):
+        r, c = key
+        return self.rows[r].get(c)
+
+    def __setitem__(self, key, value):
+        r, c = key
+        self.rows[r][c] = value
+
+
+class _Series(list):
+    def __eq__(self, other):
+        return [x == other for x in self]
+
+
+class _IndexResult(list):
+    def tolist(self):
+        return list(self)
+
+
+def setup_pandas_stub(monkeypatch, df):
+    fake_pd = types.ModuleType('pandas')
+    fake_pd.read_excel = lambda *a, **k: df
+    fake_pd.isna = lambda v: v is None or v == ''
+    monkeypatch.setitem(sys.modules, 'pandas', fake_pd)
+    monkeypatch.setattr(processing_engine, 'pd', fake_pd, raising=False)
+
+
+def test_callbacks_success_and_failure(monkeypatch, tmp_path):
+    p1 = tmp_path / "a.pdf"
+    p2 = tmp_path / "b.pdf"
+    p1.write_text("1")
+    p2.write_text("2")
+    rows = [
+        {"Description": "a.pdf", "Author": None},
+        {"Description": "b.pdf", "Author": None},
+    ]
+    df = DummyDF(rows)
+    setup_pandas_stub(monkeypatch, df)
+    monkeypatch.setattr(processing_engine, 'is_file_locked', lambda p: False)
+    monkeypatch.setattr(processing_engine, '_is_ocr_needed', lambda p: p == p1)
+    monkeypatch.setattr(
+        processing_engine, 'extract_text_from_pdf', lambda p: "text" if p == p1 else ""
+    )
+    monkeypatch.setattr(processing_engine, 'ai_extract', lambda t, p: {})
+
+    calls = {"s": 0, "f": 0, "r": 0, "o": 0}
+    def inc(key):
+        def _():
+            calls[key] += 1
+        return _
+
+    processing_engine._main_processing_loop(
+        [p1, p2],
+        str(tmp_path / "kb.xlsx"),
+        lambda *a: None,
+        lambda *a: None,
+        inc("s"),
+        inc("f"),
+        inc("r"),
+        inc("o"),
+        threading.Event(),
+    )
+
+    assert calls == {"s": 1, "f": 1, "r": 0, "o": 1}
+
+
+def test_callbacks_needs_review(monkeypatch, tmp_path):
+    p1 = tmp_path / "c.pdf"
+    p1.write_text("c")
+    rows = [{"Description": "c.pdf", "Author": None}]
+    df = DummyDF(rows)
+    setup_pandas_stub(monkeypatch, df)
+    monkeypatch.setattr(processing_engine, 'is_file_locked', lambda p: False)
+    monkeypatch.setattr(processing_engine, '_is_ocr_needed', lambda p: False)
+    monkeypatch.setattr(processing_engine, 'extract_text_from_pdf', lambda p: "text")
+    monkeypatch.setattr(processing_engine, 'ai_extract', lambda t, p: {"needs_review": True})
+
+    calls = {"s": 0, "f": 0, "r": 0, "o": 0}
+    def inc(key):
+        def _():
+            calls[key] += 1
+        return _
+
+    processing_engine._main_processing_loop(
+        [p1],
+        str(tmp_path / "kb.xlsx"),
+        lambda *a: None,
+        lambda *a: None,
+        inc("s"),
+        inc("f"),
+        inc("r"),
+        inc("o"),
+        threading.Event(),
+    )
+
+    assert calls == {"s": 1, "f": 0, "r": 1, "o": 0}


### PR DESCRIPTION
## Summary
- extend processing engine with success, failure, review and OCR callbacks
- wire callbacks through `process_folder`, `process_zip_archive` and `ProcessingWorker`
- count outcomes via new unit tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce58f1640832e9abf4e366060447c