### PR TITLE
Implement OCR callback

### DIFF
--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -50,8 +50,16 @@ def init_tesseract():
 # Initialize on module load
 TESSERACT_AVAILABLE = init_tesseract()
 
-def extract_text_from_pdf(pdf_path: Path | str) -> str:
-    """Extract text from a PDF file, using OCR if needed."""
+def extract_text_from_pdf(pdf_path: Path | str, ocr_cb=None) -> str:
+    """Extract text from a PDF file, using OCR if needed.
+
+    Parameters
+    ----------
+    pdf_path : Path | str
+        The PDF file to process.
+    ocr_cb : callable, optional
+        Callback invoked when OCR is actually performed.
+    """
     try:
         pdf_path = Path(pdf_path)
         
@@ -67,6 +75,11 @@ def extract_text_from_pdf(pdf_path: Path | str) -> str:
         # If text extraction failed and Tesseract is available, try OCR
         if TESSERACT_AVAILABLE:
             log_info(logger, f"Attempting OCR on {pdf_path}")
+            if ocr_cb:
+                try:
+                    ocr_cb()
+                except Exception as cb_exc:
+                    log_warning(logger, f"OCR callback error: {cb_exc}")
             return extract_text_with_ocr(pdf_path)
         else:
             log_warning(logger, f"No text found in {pdf_path} and OCR not available")

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -59,9 +59,7 @@ def _main_processing_loop(files_to_process, kb_filepath, progress_cb, status_cb,
             if needs_ocr:
                 status_cb("OCR", f"Performing OCR on {file_path.name}...")
 
-            text = extract_text_from_pdf(file_path)
-            if needs_ocr:
-                ocr_cb()
+            text = extract_text_from_pdf(file_path, ocr_cb if needs_ocr else None)
             if not text:
                 log_warning(logger, f"No text extracted from {file_path.name}. Marking as failure.")
                 status_cb("FAIL", f"Failed: Could not extract text from {file_path.name}")

--- a/tests/test_processing_signals.py
+++ b/tests/test_processing_signals.py
@@ -68,7 +68,11 @@ def test_ocr_callback_invoked(monkeypatch):
     monkeypatch.setattr(processing_engine.pd, 'read_excel', lambda *a, **k: df, raising=False)
     monkeypatch.setattr(processing_engine.pd, 'isna', lambda x: x == '' or x is None, raising=False)
     monkeypatch.setattr(processing_engine, 'is_file_locked', lambda p: False)
-    monkeypatch.setattr(processing_engine, 'extract_text_from_pdf', lambda p: 'text')
+    monkeypatch.setattr(
+        processing_engine,
+        'extract_text_from_pdf',
+        lambda p, cb=None: (cb() if cb else None) or 'text'
+    )
     monkeypatch.setattr(processing_engine, '_is_ocr_needed', lambda p: True)
     monkeypatch.setattr(processing_engine, 'ai_extract', lambda text, path: {})
 
@@ -82,7 +86,11 @@ def test_needs_review_callback_invoked(monkeypatch):
     monkeypatch.setattr(processing_engine.pd, 'read_excel', lambda *a, **k: df, raising=False)
     monkeypatch.setattr(processing_engine.pd, 'isna', lambda x: x == '' or x is None, raising=False)
     monkeypatch.setattr(processing_engine, 'is_file_locked', lambda p: False)
-    monkeypatch.setattr(processing_engine, 'extract_text_from_pdf', lambda p: 'text')
+    monkeypatch.setattr(
+        processing_engine,
+        'extract_text_from_pdf',
+        lambda p, cb=None: 'text'
+    )
     monkeypatch.setattr(processing_engine, '_is_ocr_needed', lambda p: False)
     monkeypatch.setattr(processing_engine, 'ai_extract', lambda text, path: {'needs_review': True})
 


### PR DESCRIPTION
## Summary
- notify when OCR is performed via `ocr_cb`
- propagate callback into `extract_text_from_pdf`
- adjust signal tests for new callback usage

## Testing
- `pytest -q`
- `ruff check ocr_utils.py processing_engine.py tests/test_processing_signals.py` *(fails: various style violations)*

------
https://chatgpt.com/codex/tasks/task_e_685ce58b0404832e862068389df67cdc