### PR TITLE
Add OCR callback functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This tool extracts model info, QA/SB numbers, and descriptions from Kyocera QA/s
 - **Automated**: Creates environment, installs requirements
 - **Modular & Logged**: Every action is recorded for audit/debug
 - **New**: Optional full-screen mode (press `F11`) and a scrolling progress log to
-  track each file.
+  track each file. The dashboard also shows when OCR was required for a PDF.
 
 
 

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -66,7 +66,14 @@ class ProcessingWorker(QThread):
         try:
             path_obj = Path(self.process_path)
             process_func = process_folder if path_obj.is_dir() else process_zip_archive
-            updated_path, updated, failed = process_func(self.process_path, self.kb_path, self.progress_updated.emit, self.status_updated.emit, lambda: None, self.cancel_event)
+            updated_path, updated, failed = process_func(
+                self.process_path,
+                self.kb_path,
+                self.progress_updated.emit,
+                self.status_updated.emit,
+                self.ocr_used_signal.emit,
+                self.cancel_event,
+            )
             self.processing_finished.emit(updated_path, updated, failed)
         except Exception as e:
             logger.error("Error in worker thread", exc_info=True)

--- a/tests/test_processing_engine.py
+++ b/tests/test_processing_engine.py
@@ -1,0 +1,98 @@
+import sys
+from pathlib import Path
+import types
+
+# Ensure repository root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+for mod in ('pandas', 'fitz'):
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+
+if 'dateutil' not in sys.modules:
+    dateutil = types.ModuleType('dateutil')
+    sys.modules['dateutil'] = dateutil
+if 'dateutil.relativedelta' not in sys.modules:
+    rd = types.ModuleType('dateutil.relativedelta')
+    class _RD:
+        def __init__(self, **kw):
+            pass
+    rd.relativedelta = _RD
+    sys.modules['dateutil.relativedelta'] = rd
+
+import processing_engine
+from config import HEADER_MAPPING
+
+
+def make_dummy_df():
+    row = {h: "" for h in HEADER_MAPPING.values()}
+    row['Description'] = 'test.pdf'
+    class DummyDF:
+        def __init__(self, data):
+            self._data = data
+            self.columns = list(data.keys())
+            self._index = [0]
+
+        def __getitem__(self, key):
+            class SeriesLike(list):
+                def __eq__(self, other):
+                    return [x == other for x in self]
+            return SeriesLike(self._data[key])
+
+        @property
+        def index(self):
+            class DummyIndex(list):
+                def __getitem__(self, mask):
+                    if isinstance(mask, list):
+                        return DummyIndex([x for x, m in zip(self, mask) if m])
+                    return list.__getitem__(self, mask)
+
+                def tolist(self):
+                    return list(self)
+
+            return DummyIndex(self._index)
+
+        @property
+        def at(self):
+            class AtAccessor:
+                def __init__(self, parent):
+                    self.parent = parent
+
+                def __getitem__(self, key):
+                    row, col = key
+                    return self.parent._data[col][row]
+
+                def __setitem__(self, key, value):
+                    row, col = key
+                    self.parent._data[col][row] = value
+
+            return AtAccessor(self)
+
+        def to_excel(self, *a, **k):
+            pass
+
+    return DummyDF({k: [v] for k, v in row.items()})
+
+
+def test_main_loop_calls_ocr_callback(monkeypatch):
+    called = {'ocr': False}
+    dummy_df = make_dummy_df()
+    dummy_pd = types.SimpleNamespace(
+        read_excel=lambda *a, **k: make_dummy_df(),
+        DataFrame=dummy_df.__class__,
+        isna=lambda x: x in (None, ""),
+    )
+    monkeypatch.setattr(processing_engine, 'pd', dummy_pd)
+    monkeypatch.setattr(processing_engine, '_is_ocr_needed', lambda x: True)
+    monkeypatch.setattr(processing_engine, 'extract_text_from_pdf', lambda x: 'text')
+    monkeypatch.setattr(processing_engine, 'ai_extract', lambda t, f: {'subject': 's', 'models': 'm'})
+
+    import threading
+    event = threading.Event()
+
+    def ocr_cb():
+        called['ocr'] = True
+
+    processing_engine._main_processing_loop([Path('test.pdf')], 'kb.xlsx', lambda m: None, lambda a,b: None, ocr_cb, event)
+
+    assert called['ocr']


### PR DESCRIPTION
## Summary
- propagate `ocr_cb` to `_main_processing_loop`
- emit OCR signal in processing worker
- document new OCR dashboard feature
- add unit test for OCR callback usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce573eae8832ebf1f3dc90b7cf170