### PR TITLE
Fix log handler fallback, update test

### DIFF
--- a/logging_utils.py
+++ b/logging_utils.py
@@ -15,14 +15,17 @@ class QtWidgetHandler(logging.Handler):
         self.text_edit = text_edit
         try:
             from PySide6 import QtCore
-            self._invoker = lambda msg: QtCore.QMetaObject.invokeMethod(
-                self.text_edit,
-                "append",
-                QtCore.Qt.QueuedConnection,
-                QtCore.Q_ARG(str, msg),
-            )
+            if hasattr(QtCore, "QMetaObject") and hasattr(QtCore, "Q_ARG"):
+                self._invoker = lambda msg: QtCore.QMetaObject.invokeMethod(
+                    self.text_edit,
+                    "append",
+                    QtCore.Qt.QueuedConnection,
+                    QtCore.Q_ARG(str, msg),
+                )
+            else:
+                raise AttributeError("QtCore missing signal helpers")
         except Exception:
-            # Fallback: direct call if PySide6 not available
+            # Fallback: direct call if PySide6 not available or incomplete
             self._invoker = lambda msg: self.text_edit.append(msg)
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/tests/test_processing_engine_logging.py
+++ b/tests/test_processing_engine_logging.py
@@ -72,7 +72,11 @@ def test_success_log_called(monkeypatch):
     monkeypatch.setattr(processing_engine.pd, 'isna', lambda x: x is None, raising=False)
     monkeypatch.setattr(processing_engine.pd.DataFrame, 'to_excel', lambda self, *a, **k: None, raising=False)
     monkeypatch.setattr(processing_engine, 'is_file_locked', lambda p: False)
-    monkeypatch.setattr(processing_engine, 'extract_text_from_pdf', lambda p: 'txt')
+    monkeypatch.setattr(
+        processing_engine,
+        'extract_text_from_pdf',
+        lambda p, cb=None: 'txt'
+    )
     monkeypatch.setattr(processing_engine, 'ai_extract', lambda text, path: {})
     monkeypatch.setattr(processing_engine, '_is_ocr_needed', lambda p: False)
 
@@ -81,7 +85,15 @@ def test_success_log_called(monkeypatch):
     monkeypatch.setattr(processing_engine, 'create_failure_log', lambda *a, **k: captured.setdefault('failure', True))
 
     cancel = SimpleNamespace(is_set=lambda: False)
-    processing_engine._main_processing_loop([Path('file.pdf')], 'kb.xlsx', lambda x: None, lambda *a: None, cancel)
+    processing_engine._main_processing_loop(
+        [Path('file.pdf')],
+        'kb.xlsx',
+        lambda x: None,
+        lambda *a: None,
+        lambda: None,
+        lambda: None,
+        cancel
+    )
 
     assert '1 record' in captured.get('success', '')
     assert 'failure' not in captured


### PR DESCRIPTION
## Summary
- ensure QtWidgetHandler falls back cleanly when PySide6 lacks signal helpers
- adjust processing engine logging test for new callback arguments

## Testing
- `ruff check logging_utils.py tests/test_processing_engine_logging.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ce8681e3c832eba0afa28dd578407