### PR TITLE
Refactor ensure_folders to use config constant

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -1,5 +1,6 @@
 # KYO QA ServiceNow File Utilities
 from version import VERSION
+import config
 
 import os
 import shutil
@@ -10,18 +11,11 @@ from datetime import datetime
 
 logger = setup_logger("file_utils")
 
-# Ensure all needed subfolders exist
-REQUIRED_FOLDERS = [
-    "logs",
-    "output",
-    "PDF_TXT",
-    "temp"
-    # add more as needed
-]
+# Folders required by the tool are defined in config.REQUIRED_FOLDERS
 
 def ensure_folders(base_folder=None):
     base = Path(base_folder) if base_folder else Path(__file__).parent
-    for folder in REQUIRED_FOLDERS:
+    for folder in config.REQUIRED_FOLDERS:
         fpath = base / folder
         try:
             fpath.mkdir(parents=True, exist_ok=True)

--- a/tests/test_ensure_folders.py
+++ b/tests/test_ensure_folders.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import file_utils
+import config
+
+
+def test_ensure_folders_uses_config(tmp_path, monkeypatch):
+    test_dirs = ["one", "two"]
+    monkeypatch.setattr(config, "REQUIRED_FOLDERS", test_dirs, raising=False)
+    base = tmp_path / "base"
+    file_utils.ensure_folders(base_folder=base)
+    for name in test_dirs:
+        assert (base / name).exists()


### PR DESCRIPTION
## Summary
- import `config` and read `REQUIRED_FOLDERS` from there
- add regression test for `ensure_folders`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf20a3404832eabdd85ebc0b90056