### PR TITLE
Remove unused imports

### DIFF
--- a/ai_extractor.py
+++ b/ai_extractor.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow AI Extractor - FINAL VERSION
-from version import VERSION
 import re
 from logging_utils import setup_logger
 from config import STANDARDIZATION_RULES, QA_NUMBER_PATTERNS, SHORT_QA_PATTERN, MODEL_PATTERNS, CHANGE_TYPE_PATTERNS

--- a/config.py
+++ b/config.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Configuration - FINAL VERSION
-from version import VERSION
 
 REQUIRED_FOLDERS = ["logs", "output", "PDF_TXT", "temp"]
 

--- a/custom_exceptions.py
+++ b/custom_exceptions.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Custom Exceptions
-from version import VERSION
 
 class QAExtractionError(Exception):
     """Raised when QA data extraction fails"""

--- a/excel_generator.py
+++ b/excel_generator.py
@@ -1,5 +1,4 @@
 # KYO QA ServiceNow Excel Generator - FINAL MEMORY-EFFICIENT VERSION
-from version import VERSION
 import openpyxl
 from openpyxl.styles import Alignment, Font, PatternFill
 import re

--- a/file_utils.py
+++ b/file_utils.py
@@ -1,6 +1,4 @@
 # KYO QA ServiceNow File Utilities
-from version import VERSION
-
 import os
 import shutil
 import time

--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -1,6 +1,4 @@
 # KYO QA ServiceNow OCR Utilities
-from version import VERSION
-
 import fitz  # PyMuPDF
 import os
 from pathlib import Path

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -1,10 +1,7 @@
 # KYO QA ServiceNow Processing Engine - FINAL VERSION (Corrected)
-from version import VERSION
 import pandas as pd
-import os, re, zipfile
+import zipfile
 from pathlib import Path
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
 
 from logging_utils import (
     setup_logger,

--- a/start_tool.py
+++ b/start_tool.py
@@ -1,12 +1,8 @@
 # KYO QA ServiceNow - Smart Python Launcher with Efficient Setup
 from version import VERSION
-import argparse
 import sys
 import subprocess
-import shutil
-import time
 import os
-import threading
 from pathlib import Path
 
 # Setup basic logging for the startup script itself

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import importlib
+from types import ModuleType
+
+# Ensure repository root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub heavy optional modules so imports don't fail
+if 'openpyxl' not in sys.modules:
+    xl = ModuleType('openpyxl')
+    styles = ModuleType('openpyxl.styles')
+    class _Dummy:
+        def __init__(self, *a, **k):
+            pass
+    styles.Alignment = _Dummy
+    styles.Font = _Dummy
+    styles.PatternFill = _Dummy
+    xl.styles = styles
+    sys.modules['openpyxl'] = xl
+    sys.modules['openpyxl.styles'] = styles
+
+sys.modules.setdefault('fitz', ModuleType('fitz'))
+
+MODULES = [
+    "ai_extractor",
+    "custom_exceptions",
+    "excel_generator",
+    "file_utils",
+    "ocr_utils",
+    "processing_engine",
+]
+
+def test_modules_importable():
+    for name in MODULES:
+        mod = importlib.import_module(name)
+        assert mod is not None


### PR DESCRIPTION
## Summary
- drop unused `VERSION` imports
- remove leftover argparse and other unused imports in start_tool
- add basic import test for key modules

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cf2090084832e87681658dd6e8df0