### PR TITLE
Define missing patterns

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,4 +34,19 @@ SUBJECT_PATTERNS = [
 CHANGE_TYPE_PATTERNS = [
     r"Type\s+of\s+change[:\s\n]*.*?(Hardware|Firmware\s+and\s+Software|Information)"
 ]
+
+# Regex patterns for extracting published dates from text.
+DATE_PATTERNS = [
+    r"\d{4}[/-]\d{1,2}[/-]\d{1,2}",  # 2025-06-26 or 2025/06/26
+    r"\d{1,2}[/-]\d{1,2}[/-]\d{4}",  # 06/26/2025 or 6-26-2025
+    r"\d{1,2}\s*(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s*\d{4}",
+    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s*\d{1,2},?\s*\d{4}",
+]
+
+# Patterns to help identify software bulletins.
+APP_SOFTWARE_PATTERNS = {
+    "keywords": r"\b(?:software|application|app)\b",
+    "version": r"(?:version|ver\.?|v)\s*\d+(?:\.\d+)*",
+}
+
 STANDARDIZATION_RULES = {"default_author": "Knowledge Import"}

--- a/tests/test_config_patterns.py
+++ b/tests/test_config_patterns.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+import re
+
+# Ensure repository root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from config import DATE_PATTERNS, APP_SOFTWARE_PATTERNS
+
+
+def test_date_patterns_match_common_format():
+    sample = 'Published: 2025-06-26'
+    assert any(re.search(p, sample) for p in DATE_PATTERNS)
+
+
+def test_app_software_patterns_keyword_and_version():
+    text = 'This software bulletin covers app version 1.2.3.'
+    assert re.search(APP_SOFTWARE_PATTERNS["keywords"], text, re.IGNORECASE)
+    assert re.search(APP_SOFTWARE_PATTERNS["version"], text, re.IGNORECASE)


### PR DESCRIPTION
## Summary
- add patterns for dates and software bulletins in `config.py`
- test the new configs to ensure regex match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf207f570832e879a72bf7991904f