### PR TITLE
Update version to v25.0.1 across project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v25.0.1 (2025-06-28)
+-
+
 ## v25.0.0 (2025-06-26)
 - Updated docs and internal references to version 25.0.0.
 - Adjusted installer fallback version to ensure banner matches.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KYO QA ServiceNow Knowledge Tool v25.0.0
+# KYO QA ServiceNow Knowledge Tool v25.0.1
 
 ## How to Set Up and Run (Modular, Fully Logged)
 
@@ -8,7 +8,7 @@
 - **Optional:** All dependencies listed in `requirements.txt` (auto-installed if you run `start_tool.py`)
 
 ### 2. Folder Structure
-KYO_QA_ServiceNow_Knowledge_Tool_v25.0.0/
+KYO_QA_ServiceNow_Knowledge_Tool_v25.0.1/
 ├── START.bat
 ├── start_tool.py
 ├── requirements.txt
@@ -26,7 +26,7 @@ KYO_QA_ServiceNow_Knowledge_Tool_v25.0.0/
 ├── logs/(auto-created)
 ├── output/(auto-created)
 └── venv/(auto-created)
-# KYO QA ServiceNow Knowledge Tool v25.0.0 – Directory Breakdown
+# KYO QA ServiceNow Knowledge Tool v25.0.1 – Directory Breakdown
 
 This tool extracts model info, QA/SB numbers, and descriptions from Kyocera QA/service PDFs using OCR + pattern recognition. It outputs a ServiceNow-ready Excel file and logs every step. No PDFs are retained.
 
@@ -99,7 +99,7 @@ If you plan to run or test the tool locally, first install the required Python
 packages with the helper script:
 
 ```bash
-cd KYO_QA_ServiceNow_Knowledge_Tool_v25.0.0
+cd KYO_QA_ServiceNow_Knowledge_Tool_v25.0.1
 ./scripts/setup_env.sh
 ```
 
@@ -115,11 +115,11 @@ pytest -q
 
 The tests rely on `pandas`, `PyMuPDF`, and the rest of the packages listed in
 `requirements.txt`. If `PyMuPDF` is missing you will see import errors. As of
-v25.0.0, unused packages `xlsxwriter` and `halo` were removed to keep the
+v25.0.1, unused packages `xlsxwriter` and `halo` were removed to keep the
 environment lean.
 
 ### 4. Versioning
-- This is the modular, logging-enabled release: **v25.0.0**
+- This is the modular, logging-enabled release: **v25.0.1**
 - Each file and log is stamped with its version.
 - All updates are tracked in `CHANGELOG.md`.
 

--- a/run.py
+++ b/run.py
@@ -1,8 +1,8 @@
-# KYO QA ServiceNow Tool - Python Package Installer v25.0.0
+# KYO QA ServiceNow Tool - Python Package Installer v25.0.1
 import sys, subprocess, importlib.metadata
 
 try: from version import VERSION
-except ImportError: VERSION = "25.0.0"
+except ImportError: VERSION = "v25.0.1"
 
 # FIXED: Added 'ollama' to ensure the AI component can run.
 REQUIRED_PACKAGES = ["pandas", "openpyxl", "PyMuPDF", "pytesseract", "ollama"]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,4 +7,4 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import run
 
 def test_run_version_constant():
-    assert run.VERSION == "25.0.0"
+    assert run.VERSION == "v25.0.1"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,4 +7,4 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from version import VERSION, get_version
 
 def test_get_version():
-    assert get_version() == VERSION == "25.0.0"
+    assert get_version() == VERSION == "v25.0.1"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,8 @@
 # KYO QA Knowledge Tool Versioning
 VERSION = "v25.0.1"
+
+
+def get_version() -> str:
+    """Return the current version string."""
+    return VERSION
+


### PR DESCRIPTION
## Summary
- add `get_version()` helper and bump version constant to `v25.0.1`
- update README/CHANGELOG references
- align tests with new version
- bump installer fallback version

## Testing
- `python3 -m py_compile version.py run.py tests/test_version.py tests/test_run.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_685f79408ac8832e985fddf063ecd73b