### PR TITLE
Add missing dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ pdfminer.six
 regex
 requests
 PyPDF2>=3.0.1
+PyMuPDF
+python-dateutil
+Pillow
+ollama

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+REQUIRED_PACKAGES = {"PyMuPDF", "Pillow", "python-dateutil", "ollama"}
+
+def test_new_requirements_present():
+    req_file = Path(__file__).resolve().parents[1] / "requirements.txt"
+    content = req_file.read_text()
+    missing = [pkg for pkg in REQUIRED_PACKAGES if pkg not in content]
+    assert not missing, f"Missing packages in requirements.txt: {missing}"


### PR DESCRIPTION
## Summary
- include additional dependencies `PyMuPDF`, `python-dateutil`, `Pillow`, and `ollama`
- add test to ensure new dependencies are present

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_requirements.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_685f79384648832e9b3fa5260d579c9c