### PR TITLE
Remove dummy defs in processing_engine

### DIFF
--- a/processing_engine.py
+++ b/processing_engine.py
@@ -1,30 +1,3 @@
-# processing_engine.py
-
-import os
-import pandas as pd
-# import your extractors, ocr_utils, etc. here as needed
-
-def process_folder(folder_path, kb_path, progress_cb=None, status_cb=None, ocr_cb=None, review_cb=None, cancel_flag=None):
-    # Dummy example logic
-    # Replace this with your actual folder processing logic
-    updated, failed = 0, 0
-    for file in os.listdir(folder_path):
-        if file.lower().endswith(".pdf"):
-            # ... PDF processing code ...
-            updated += 1
-            if progress_cb:
-                progress_cb(1)
-    return None, updated, failed
-
-def process_zip_archive(zip_path, kb_path, progress_cb=None, status_cb=None, ocr_cb=None, review_cb=None, cancel_flag=None):
-    # Dummy example logic
-    # Replace this with your actual ZIP processing logic
-    updated, failed = 0, 0
-    # ... ZIP processing code ...
-    return None, updated, failed
-
-# Add any helper functions below, but DO NOT import from your GUI
-
 # KYO QA ServiceNow Processing Engine - FINAL VERSION (Corrected)
 from version import VERSION
 import pandas as pd

--- a/tests/test_processing_engine_interface.py
+++ b/tests/test_processing_engine_interface.py
@@ -1,0 +1,60 @@
+import sys
+import types
+from pathlib import Path
+import inspect
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub heavy dependencies if missing
+for mod in ('pandas', 'fitz'):
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+# Stub minimal PySide6 for ai_extractor import
+if 'PySide6' not in sys.modules:
+    pyside6 = types.ModuleType('PySide6')
+    qtwidgets = types.ModuleType('PySide6.QtWidgets')
+    qtcore = types.ModuleType('PySide6.QtCore')
+    for attr in ['QApplication','QMainWindow','QWidget','QVBoxLayout','QLabel','QPushButton','QFileDialog','QProgressBar','QTextEdit','QMessageBox','QHBoxLayout','QGroupBox']:
+        setattr(qtwidgets, attr, object)
+    qtcore.QThread = object
+    class DummySignal:
+        def __init__(self, *a, **k):
+            pass
+    qtcore.Signal = DummySignal
+    qtcore.Qt = types.SimpleNamespace()
+    pyside6.QtWidgets = qtwidgets
+    pyside6.QtCore = qtcore
+    sys.modules['PySide6'] = pyside6
+    sys.modules['PySide6.QtWidgets'] = qtwidgets
+    sys.modules['PySide6.QtCore'] = qtcore
+# Stub ai_extractor to avoid circular import
+if 'ai_extractor' not in sys.modules:
+    ai_extractor = types.ModuleType('ai_extractor')
+    ai_extractor.ai_extract = lambda text, path: {}
+    sys.modules['ai_extractor'] = ai_extractor
+if 'dateutil' not in sys.modules:
+    dateutil = types.ModuleType('dateutil')
+    sys.modules['dateutil'] = dateutil
+if 'dateutil.relativedelta' not in sys.modules:
+    rd = types.ModuleType('dateutil.relativedelta')
+    class _RD:
+        def __init__(self, **kw):
+            pass
+    rd.relativedelta = _RD
+    sys.modules['dateutil.relativedelta'] = rd
+
+import processing_engine
+
+
+def test_process_folder_signature():
+    sig = inspect.signature(processing_engine.process_folder)
+    assert 'kb_filepath' in sig.parameters
+    assert 'progress_cb' in sig.parameters
+    assert 'status_cb' in sig.parameters
+
+
+def test_process_zip_archive_signature():
+    sig = inspect.signature(processing_engine.process_zip_archive)
+    assert 'kb_filepath' in sig.parameters
+    assert 'progress_cb' in sig.parameters
+    assert 'status_cb' in sig.parameters


### PR DESCRIPTION
## Summary
- drop placeholder `process_folder` and `process_zip_archive` functions
- verify new interface using small test

## Testing
- `python -m py_compile processing_engine.py tests/test_processing_engine_interface.py`
- `pytest tests/test_processing_engine_interface.py -q`
- `pytest -q` *(fails: PySide6 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f79344a1c832ebaeccb82383db688