### PR TITLE
Add fitz import

### DIFF
--- a/processing_engine.py
+++ b/processing_engine.py
@@ -2,6 +2,7 @@
 from version import VERSION
 import pandas as pd
 import os, re, zipfile
+import fitz  # PyMuPDF
 from pathlib import Path
 from datetime import datetime
 from dateutil.relativedelta import relativedelta

--- a/tests/test_processing_engine_interface.py
+++ b/tests/test_processing_engine_interface.py
@@ -58,3 +58,8 @@ def test_process_zip_archive_signature():
     assert 'kb_filepath' in sig.parameters
     assert 'progress_cb' in sig.parameters
     assert 'status_cb' in sig.parameters
+
+
+def test_fitz_import_available():
+    """Ensure processing_engine exposes the fitz module."""
+    assert hasattr(processing_engine, 'fitz')


### PR DESCRIPTION
## Summary
- add missing `fitz` import in processing_engine
- ensure `fitz` is exposed from processing_engine in interface tests

## Testing
- `python -m py_compile processing_engine.py`
- `pytest tests/test_processing_engine_interface.py::test_fitz_import_available -q` *(fails: NameError: name 'main' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f7fa8c608832ea992049a29152e54