### PR TITLE
Remove stray main lines

### DIFF
--- a/ai_extractor.py
+++ b/ai_extractor.py
@@ -39,7 +39,6 @@ from logging_utils import setup_logger
 
 import data_harvesters
 from data_harvesters import harvest_metadata
-main
 from extract.common import bulletproof_extraction
 
 logger = setup_logger("gui")
@@ -211,4 +210,3 @@ if __name__ == "__main__":
     win = QAApp()
     win.show()
     sys.exit(app.exec())
-main

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -217,5 +217,3 @@ if __name__ == "__main__":
     win = QAApp()
     win.show()
     sys.exit(app.exec())
-
-main

--- a/start_tool.py
+++ b/start_tool.py
@@ -55,7 +55,5 @@ if __name__ == "__main__":
     except ImportError:
         print("[ERROR] PyPDF2 failed to import even after install.")
 
-main
     print("\n--- All dependencies satisfied. Launching app... ---\n")
     launch_application()
-main

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,6 @@ if 'PySide6' not in sys.modules:
         def __init__(self, *args, **kwargs):
             pass
     qtgui.QCursor = QCursor
-main
 
     sys.modules['PySide6'] = pyside6
     sys.modules['PySide6.QtWidgets'] = qtwidgets

--- a/tests/test_start_tool.py
+++ b/tests/test_start_tool.py
@@ -24,4 +24,3 @@ def test_main_block_contains_launch_call():
     assert '\nmain\n' not in src
     start = src.index('if __name__ == "__main__"')
     assert 'launch_application()' in src[start:]
-main

--- a/version.py
+++ b/version.py
@@ -7,5 +7,4 @@ def get_version() -> str:
     """Return the current version string."""
     return VERSION
 
-main
 


### PR DESCRIPTION
## Summary
- remove leftover `main` strings littered in source and test files

## Testing
- `ruff check`
- `pytest -q` *(fails: tests/test_ai_extractor.py::test_ai_extract_basic)*

------
https://chatgpt.com/codex/tasks/task_e_685f8522a7d8832eb0c13d6c3ab8e6fd