### PR TITLE
Add ollama requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pillow>=10.3.0
 pytesseract>=0.3.11
 colorama>=0.4.6
 python-dateutil>=2.9.0
+ollama>=0.1.2


### PR DESCRIPTION
## Summary
- add `ollama>=0.1.2` to requirements

## Testing
- `pytest tests/test_requirements.py -q`
- `ruff check requirements.txt` *(fails: simple statements must be separated by newlines)*

------
https://chatgpt.com/codex/tasks/task_e_6861cd0608a0832ea4a35aa6e381697f