### PR TITLE
Improve harvest metadata

### DIFF
--- a/data_harvesters.py
+++ b/data_harvesters.py
@@ -120,10 +120,25 @@ def harvest_author(text: str) -> str:
 
 
 def harvest_metadata(text: str) -> dict:
-    """Extract device models from raw text."""
+    """Extract key metadata like models and QA numbers from raw text."""
+
     models = sorted(harvest_models_from_text(text))
+    full_qa = harvest_qa_number(text)
+    short_qa = harvest_short_qa_number(full_qa)
+    published_date = harvest_date(text)
+    subject = harvest_subject(text)
+    author = harvest_author(text)
+
     models_str = ", ".join(models) if models else "Not Found"
-    return {"models": models_str}
+
+    return {
+        "models": models_str,
+        "full_qa_number": full_qa,
+        "short_qa_number": short_qa,
+        "published_date": published_date,
+        "subject": subject if subject else "No Subject Found",
+        "author": author,
+    }
 
 
 def ai_extract(text: str, pdf_path: Path) -> dict:

--- a/tests/test_harvest_metadata.py
+++ b/tests/test_harvest_metadata.py
@@ -12,6 +12,13 @@ def test_harvest_metadata_finds_models():
     assert result["models"] == "TASKalfa 1230i"
 
 
+def test_harvest_metadata_includes_qa_numbers():
+    text = "Ref. No. AB-1234 (E22)\nModel:\nTASKalfa 2550ci"
+    result = harvest_metadata(text)
+    assert result["full_qa_number"] == "AB-1234"
+    assert result["short_qa_number"] == "E22"
+
+
 def test_ai_extract_uses_metadata_models(monkeypatch, tmp_path):
     monkeypatch.setattr(
         'extract.common.bulletproof_extraction',


### PR DESCRIPTION
## Summary
- enrich `harvest_metadata` with QA number logic and other metadata
- verify QA numbers via new test

## Testing
- `ruff check data_harvesters.py tests/test_harvest_metadata.py`
- `pytest -q` *(fails: ImportError: cannot import name 'Font'...)*

------
https://chatgpt.com/codex/tasks/task_e_6861cd09f094832e8860500c45c3dd89