### PR TITLE
Add bulletproof extraction reexport

### DIFF
--- a/ai_extractor.py
+++ b/ai_extractor.py
@@ -1,4 +1,10 @@
-"""Convenience wrapper to expose AI extraction helpers."""
+"""Convenience wrapper to expose AI extraction helpers.
+
+This module re-exports select functions so they can be imported from a single
+location. ``bulletproof_extraction`` is now included from :mod:`extract.common`
+for easy access.
+"""
+
 from data_harvesters import ai_extract, harvest_metadata
 from extract.common import bulletproof_extraction
 

--- a/tests/test_ai_extractor.py
+++ b/tests/test_ai_extractor.py
@@ -14,10 +14,25 @@ def test_ai_extract_basic(monkeypatch):
         "Model:\nTASKalfa 3005i\n"
     )
 
-    monkeypatch.setattr("data_harvesters.harvest_metadata", lambda *a, **k: {
-        "published_date": "2024-01-01",
-        "author": "Tester",
-    })
+    monkeypatch.setattr(
+        "data_harvesters.harvest_metadata",
+        lambda *a, **k: {
+            "published_date": "2024-01-01",
+            "author": "Tester",
+            "models": "TASKalfa 3005i",
+        },
+    )
+    monkeypatch.setattr("ocr_utils.get_pdf_metadata", lambda *_: {})
+
+    monkeypatch.setattr(
+        "data_harvesters.bulletproof_extraction",
+        lambda *a, **k: {
+            "full_qa_number": "AB-1234",
+            "short_qa_number": "E22",
+            "models": "TASKalfa 3005i",
+            "document_type": "Service Bulletin",
+        },
+    )
 
     result = ai_extractor.ai_extract(sample_text, Path("file.pdf"))
 
@@ -37,3 +52,8 @@ def test_reexport_functions():
 
     # ai_extract should remain callable
     assert callable(ai_extractor.ai_extract)
+
+
+def test_public_api_contains_bulletproof():
+    """Ensure ai_extractor.__all__ exposes bulletproof_extraction."""
+    assert "bulletproof_extraction" in ai_extractor.__all__


### PR DESCRIPTION
## Summary
- re-export `bulletproof_extraction` in `ai_extractor`
- test `ai_extractor.__all__` and ensure extraction helpers work

## Testing
- `pytest tests/test_ai_extractor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cd0cd0b0832ea93d1a9840ce6e2a