### PR TITLE
Add PySide6 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 - **Python 3.11.x (64-bit):** Download Python 3.11.9 Windows Installer or use a portable version in `python-3.11.9` folder.
 - **Tesseract OCR:** Tesseract Windows Installer (UB Mannheim) or place portable binary in `tesseract` folder.
-- **Dependencies:** Listed in `requirements.txt` (auto-installed via `start_tool.py`).
+- **Dependencies:** Listed in `requirements.txt` (auto-installed via `start_tool.py`). The GUI requires `PySide6` and PDF processing relies on `PyMuPDF`.
+- **Install PySide6:** If it doesn't auto-install, run `pip install PySide6` inside the `venv`.
 
 ### 2. Folder Structure
 
@@ -125,7 +126,7 @@ Run tests with:
 pytest -q
 ```
 
-Requires `pandas`, `PyMuPDF`, `openpyxl`, `pytesseract`, `python-dateutil`, `colorama`. Ensure Tesseract is installed or in `tesseract` folder for OCR tests.
+Requires `pandas`, `PyMuPDF`, `PySide6`, `openpyxl`, `pytesseract`, `python-dateutil`, `colorama`. Ensure Tesseract is installed or in `tesseract` folder for OCR tests.
 
 ### 6. Versioning
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pandas>=2.2.2
 PyMuPDF>=1.24.3
+PySide6>=6.6.1
 openpyxl>=3.1.2
 Pillow>=10.3.0
 pytesseract>=0.3.11

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-REQUIRED_PACKAGES = {"PyMuPDF", "Pillow", "python-dateutil", "ollama"}
+REQUIRED_PACKAGES = {"PyMuPDF", "Pillow", "python-dateutil", "ollama", "PySide6"}
 
 def test_new_requirements_present():
     req_file = Path(__file__).resolve().parents[1] / "requirements.txt"


### PR DESCRIPTION
## Summary
- note that PySide6 is required in documentation
- add PySide6 to requirements list
- verify requirements via test

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Font' from 'styles')*

------
https://chatgpt.com/codex/tasks/task_e_6861cd3bf808832eaa4c97155ceb3f4d