### PR TITLE
Update dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - **Python 3.11.x (64-bit):** Download Python 3.11.9 Windows Installer or use a portable version in `python-3.11.9` folder.
 - **Tesseract OCR:** Tesseract Windows Installer (UB Mannheim) or place portable binary in `tesseract` folder.
-- **Dependencies:** Listed in `requirements.txt` (auto-installed via `start_tool.py`). The GUI requires `PySide6` and PDF processing relies on `PyMuPDF`.
+- **Dependencies:** Listed in `requirements.txt` (auto-installed via `start_tool.py`). Key packages include `PySide6` for the GUI, `PyMuPDF` for PDF handling, `Pillow` for images, and `ollama` for AI features.
 - **Install PySide6:** If it doesn't auto-install, run `pip install PySide6` inside the `venv`.
 
 ### 2. Folder Structure
@@ -128,7 +128,7 @@ Run tests with:
 pytest -q
 ```
 
-Requires `pandas`, `PyMuPDF`, `PySide6`, `openpyxl`, `pytesseract`, `python-dateutil`, `colorama`. Ensure Tesseract is installed or in `tesseract` folder for OCR tests.
+Requires `pandas`, `PyMuPDF`, `PySide6`, `openpyxl`, `pytesseract`, `python-dateutil`, `colorama`, `Pillow`, and `ollama`. Ensure Tesseract is installed or in `tesseract` folder for OCR tests.
 
 ### 6. Versioning
 

--- a/tests/test_readme_dependencies.py
+++ b/tests/test_readme_dependencies.py
@@ -3,4 +3,5 @@ from pathlib import Path
 
 def test_readme_mentions_dependencies():
     text = Path(__file__).resolve().parents[1].joinpath('README.md').read_text()
-    assert 'PyMuPDF' in text and 'PySide6' in text
+    for dep in ['PyMuPDF', 'PySide6', 'Pillow', 'ollama']:
+        assert dep in text


### PR DESCRIPTION
## Summary
- mention `Pillow` and `ollama` in README
- verify README lists new dependencies in unit tests

## Testing
- `ruff check .` *(fails: unrecognized subcommand '.'; ran `ruff check .`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl.utils')*

------
https://chatgpt.com/codex/tasks/task_e_6861dc3fb940832e9b2d91f49253bfa3