### PR TITLE
Add needs-review test for process_single_pdf

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -12,6 +12,7 @@ from kyo_review_tool import ReviewWindow
 from version import VERSION
 import logging_utils
 import processing_engine
+import sys
 
 # Ensure tests that stub openpyxl don't interfere with later imports
 sys.modules.pop("openpyxl", None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,3 +66,41 @@ if 'dateutil.relativedelta' not in sys.modules:
     rd = types.ModuleType('dateutil.relativedelta')
     rd.relativedelta = lambda **kw: None
     sys.modules['dateutil.relativedelta'] = rd
+
+if 'openpyxl' not in sys.modules:
+    openpyxl = types.ModuleType('openpyxl')
+
+    class _DummyWB:
+        def __init__(self):
+            self.active = types.SimpleNamespace()
+
+        def save(self, *a, **k):
+            pass
+
+    def Workbook():
+        return _DummyWB()
+
+    def load_workbook(*a, **k):
+        return _DummyWB()
+
+    styles = types.ModuleType('styles')
+    styles.PatternFill = lambda *a, **k: None
+    styles.Alignment = lambda *a, **k: None
+    styles.Font = lambda *a, **k: None
+    formatting = types.ModuleType('formatting')
+    rule = types.ModuleType('rule')
+    rule.FormulaRule = lambda *a, **k: None
+    formatting.rule = rule
+    utils = types.ModuleType('utils')
+    utils.get_column_letter = lambda i: 'A'
+
+    openpyxl.Workbook = Workbook
+    openpyxl.load_workbook = load_workbook
+    openpyxl.styles = styles
+    openpyxl.formatting = formatting
+    openpyxl.utils = utils
+    sys.modules['openpyxl'] = openpyxl
+    sys.modules['openpyxl.styles'] = styles
+    sys.modules['openpyxl.formatting'] = formatting
+    sys.modules['openpyxl.formatting.rule'] = rule
+    sys.modules['openpyxl.utils'] = utils

--- a/tests/test_app_alias.py
+++ b/tests/test_app_alias.py
@@ -28,10 +28,8 @@ if 'openpyxl' not in sys.modules:
     sys.modules['openpyxl'] = openpyxl
     sys.modules['openpyxl.styles'] = styles
     sys.modules['openpyxl.formatting'] = formatting
-    sys.modules['openpyxl.formatting.rule'] = rule_mod
-    sys.modules['openpyxl.utils'] = utils
-    sys.modules['openpyxl.formatting'] = formatting
     sys.modules['openpyxl.formatting.rule'] = rule
+    sys.modules['openpyxl.utils'] = utils
 
 import kyo_qa_tool_app
 

--- a/tests/test_process_single_pdf_review.py
+++ b/tests/test_process_single_pdf_review.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+from queue import Queue
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import processing_engine
+
+
+def test_process_single_pdf_needs_review(monkeypatch, tmp_path):
+    txt_dir = tmp_path / "txt"
+    txt_dir.mkdir()
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    monkeypatch.setattr(processing_engine, "PDF_TXT_DIR", txt_dir)
+    monkeypatch.setattr(processing_engine, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(processing_engine, "_is_ocr_needed", lambda p: False)
+    monkeypatch.setattr(processing_engine, "extract_text_from_pdf", lambda p: "no models here")
+
+    monkeypatch.setattr(
+        processing_engine,
+        "harvest_all_data",
+        lambda text, filename: {
+            "models": "Not Found",
+            "full_qa_number": "QA1234",
+            "short_qa_number": "1234",
+            "published_date": "",
+            "subject": "Test",
+            "author": "",
+            "short_description": "",
+        },
+    )
+
+    pdf_path = tmp_path / "file.pdf"
+    pdf_path.write_text("dummy")
+    q = Queue()
+
+    result = processing_engine.process_single_pdf(pdf_path, q)
+
+    assert result["status"] == "Needs Review"
+    review_file = txt_dir / "file.pdf.txt"
+    assert review_file.exists()
+    review_info = result["review_info"]
+    assert {
+        "filename",
+        "reason",
+        "txt_path",
+        "pdf_path",
+        "text_content",
+    } <= review_info.keys()
+    assert review_info["txt_path"] == str(review_file)
+    assert review_info["pdf_path"] == str(pdf_path)
+


### PR DESCRIPTION
## Summary
- stub `openpyxl` in tests so imports don't fail
- fix `test_app_alias` openpyxl stub
- import `sys` inside `kyo_qa_tool_app`
- test that PDFs without models trigger review file creation

## Testing
- `ruff check tests/test_process_single_pdf_review.py tests/conftest.py tests/test_app_alias.py kyo_qa_tool_app.py`
- `pytest tests/test_process_single_pdf_review.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e4bc69e0832eb30a1185a4ca0d81