### PR TITLE
Ensure folders before CLI processing

### DIFF
--- a/cli_runner.py
+++ b/cli_runner.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from processing_engine import process_folder, process_zip_archive
 from logging_utils import setup_logger
+from file_utils import ensure_folders
 
 logger = setup_logger("cli")
 
@@ -21,6 +22,9 @@ def main():
     parser.add_argument("--zip", help="Path to a zip file of PDFs")
     parser.add_argument("--excel", help="Path to existing Excel template")
     args = parser.parse_args()
+
+    # Ensure required output folders exist before processing
+    ensure_folders()
 
     if not args.excel or not Path(args.excel).exists():
         print("\nERROR: You must provide a valid Excel file using --excel\n")

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -1,0 +1,50 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure repo root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+try:
+    import openpyxl  # type: ignore
+except ModuleNotFoundError:
+    openpyxl = types.ModuleType('openpyxl')
+    styles = types.ModuleType('styles')
+    styles.PatternFill = object
+    styles.Alignment = object
+    utils = types.ModuleType('utils')
+    utils.get_column_letter = lambda x: x
+    openpyxl.styles = styles
+    openpyxl.utils = utils
+    openpyxl.Workbook = object
+    sys.modules['openpyxl'] = openpyxl
+    sys.modules['openpyxl.styles'] = styles
+    sys.modules['openpyxl.utils'] = utils
+
+import cli_runner
+
+
+def test_cli_main_calls_ensure_folders(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_ensure():
+        called['called'] = True
+
+    monkeypatch.setattr(cli_runner, 'ensure_folders', fake_ensure)
+    monkeypatch.setattr(cli_runner, 'process_folder', lambda *a, **k: None)
+    monkeypatch.setattr(cli_runner, 'process_zip_archive', lambda *a, **k: None)
+    monkeypatch.setattr('builtins.print', lambda *a, **k: None)
+
+    excel = tmp_path / 'base.xlsx'
+    excel.write_text('x')
+
+    argv = [
+        'cli_runner',
+        '--folder', str(tmp_path),
+        '--excel', str(excel)
+    ]
+    monkeypatch.setattr(sys, 'argv', argv)
+
+    cli_runner.main()
+
+    assert called.get('called')


### PR DESCRIPTION
## Summary
- create required directories on CLI startup
- add regression test for CLI runner

## Testing
- `ruff check cli_runner.py tests/test_cli_runner.py`
- `pytest -q tests/test_cli_runner.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl.utils'; 'openpyxl' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_6861e49dfb20832eb7b09f19f98691e9