### PR TITLE
Replace deprecated debug harvester call

### DIFF
--- a/debug_harvester.py
+++ b/debug_harvester.py
@@ -2,7 +2,7 @@
 import sys
 from pathlib import Path
 from ocr_utils import extract_text_from_pdf, TESSERACT_AVAILABLE
-from data_harvesters import harvest_data_from_text
+from data_harvesters import harvest_all_data
 from config import MODEL_PATTERNS
 import time
 
@@ -37,8 +37,8 @@ def test_model_extraction(pdf_path: Path):
     print(f"\n[Step 3: Harvesting Models]")
     print(f"-> Using {len(MODEL_PATTERNS)} patterns from config.py")
     
-    # We use harvest_data_from_text as it returns a dictionary we can inspect
-    extracted_data = harvest_data_from_text(raw_text)
+    # Use harvest_all_data to extract models and related metadata
+    extracted_data = harvest_all_data(raw_text, pdf_path.name)
     found_models_str = extracted_data.get("models")
 
     # 4. Print the final results

--- a/tests/test_debug_harvester.py
+++ b/tests/test_debug_harvester.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import types
+
+# Ensure repository root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import debug_harvester
+
+def test_debug_harvester_uses_new_harvester(monkeypatch, capsys, tmp_path):
+    # Fake text extraction
+    monkeypatch.setattr(debug_harvester, "extract_text_from_pdf", lambda p: "Model: TASKalfa 4002i")
+    # Capture call to harvest_all_data
+    called = {}
+    def fake_harvest(text, filename):
+        called['text'] = text
+        called['filename'] = filename
+        return {"models": "TASKalfa 4002i"}
+    monkeypatch.setattr(debug_harvester, "harvest_all_data", fake_harvest)
+
+    pdf_file = tmp_path / "test.pdf"
+    pdf_file.write_text("dummy")
+
+    debug_harvester.test_model_extraction(pdf_file)
+    out = capsys.readouterr().out
+
+    assert called['filename'] == "test.pdf"
+    assert "SUCCESS" in out


### PR DESCRIPTION
## Summary
- update `debug_harvester.py` to use `harvest_all_data`
- add regression test for debug script

## Testing
- `ruff check . | head -n 5`
- `pytest tests/test_debug_harvester.py -q`
- manual debug script run with stubbed OCR


------
https://chatgpt.com/codex/tasks/task_e_6861e4abfb08832e9536e0e149f23776