### PR TITLE
Add extract dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - **Python 3.11.x (64-bit):** Download Python 3.11.9 Windows Installer or use a portable version in `python-3.11.9` folder.
 - **Tesseract OCR:** Tesseract Windows Installer (UB Mannheim) or place portable binary in `tesseract` folder.
-- **Dependencies:** Listed in `requirements.txt` (auto-installed via `start_tool.py`). Key packages include `PySide6` for the GUI, `PyMuPDF` for PDF handling, `Pillow` for images, and `ollama` for AI features.
+- **Dependencies:** Listed in `requirements.txt` (auto-installed via `start_tool.py`). Key packages include `PySide6` for the GUI, `PyMuPDF` for PDF handling, `Pillow` for images, `ollama` for AI features, and `extract` for extra data extraction helpers.
 - **Install PySide6:** If it doesn't auto-install, run `pip install PySide6` inside the `venv`.
 
 ### 2. Folder Structure

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytesseract>=0.3.11
 colorama>=0.4.6
 python-dateutil>=2.9.0
 ollama>=0.1.2
+extract

--- a/tests/test_ai_extractor.py
+++ b/tests/test_ai_extractor.py
@@ -1,0 +1,46 @@
+import importlib
+import types
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_bulletproof_import():
+    # Prepare dummy extract.common module
+    extract_mod = types.ModuleType("extract")
+    common_mod = types.ModuleType("extract.common")
+
+    def bulletproof_extraction():
+        return "dummy"
+
+    common_mod.bulletproof_extraction = bulletproof_extraction
+    extract_mod.common = common_mod
+
+    sys.modules["extract"] = extract_mod
+    sys.modules["extract.common"] = common_mod
+
+    # Stub data_harvesters with minimal API
+    dh = types.ModuleType("data_harvesters")
+
+    def ai_extract():
+        return None
+
+    def harvest_metadata():
+        return None
+
+    dh.ai_extract = ai_extract
+    dh.harvest_metadata = harvest_metadata
+    sys.modules["data_harvesters"] = dh
+
+    ai_ext = importlib.reload(importlib.import_module("ai_extractor"))
+    assert ai_ext.bulletproof_extraction() == "dummy"
+    assert "bulletproof_extraction" in ai_ext.__all__
+
+    # Cleanup
+    del sys.modules["extract.common"]
+    del sys.modules["extract"]
+    del sys.modules["data_harvesters"]
+    del sys.modules["ai_extractor"]
+


### PR DESCRIPTION
## Summary
- reference `extract` in requirements
- document `extract` in the README
- stub out `extract` and `data_harvesters` in a new unit test to ensure `ai_extractor` imports correctly

## Testing
- `ruff check tests/test_ai_extractor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686227bc4844832eb28b71ddf44ce7bf