### PR TITLE
Streamline ExcelWriter

### DIFF
--- a/excel_generator.py
+++ b/excel_generator.py
@@ -23,28 +23,6 @@ FAILED_FILL = PatternFill(start_color="9C0006", end_color="9C0006", fill_type="s
 SUCCESS_FILL = PatternFill(fill_type=None)
 
 
-class ExcelWriter:
-    """Lightweight Excel writer used for unit tests."""
-
-    def __init__(self, output_path: str, headers: list[str]):
-        self.output_path = output_path
-        self.headers = headers
-        self.wb = openpyxl.Workbook()
-        self.ws = self.wb.active
-        self.ws.append(headers)
-
-    def add_row(self, data: dict):
-        row = [data.get(h, "") for h in self.headers]
-        self.ws.append(row)
-        status = data.get("processing_status")
-        cell = self.ws.cell(row=self.ws.max_row, column=1)
-        if status == "Needs Review":
-            cell.fill = NEEDS_REVIEW_FILL
-        elif status == "Failed":
-            cell.fill = FAILED_FILL
-
-    def save(self):
-        self.wb.save(self.output_path)
 
 DEFAULT_TEMPLATE_HEADERS = [
     "Active",
@@ -83,30 +61,6 @@ DEFAULT_TEMPLATE_HEADERS = [
 ]
 
 
-class ExcelWriter:
-    """Minimal writer used in tests to verify row coloring."""
-
-    def __init__(self, filepath, headers):
-        self.filepath = filepath
-        self.headers = [h.strip() for h in headers]
-        self.workbook = openpyxl.Workbook()
-        self.sheet = self.workbook.active
-        self.sheet.append(self.headers)
-
-    def add_row(self, data):
-        row = [data.get(h, "") for h in self.headers]
-        self.sheet.append(row)
-        status = data.get("processing_status", "Success")
-        fill = {
-            "Needs Review": NEEDS_REVIEW_FILL,
-            "Failed": FAILED_FILL,
-        }.get(status)
-        if fill:
-            for cell in self.sheet[self.sheet.max_row]:
-                cell.fill = fill
-
-    def save(self):
-        self.workbook.save(self.filepath)
 
 
 def sanitize_for_excel(value):
@@ -169,7 +123,7 @@ def apply_excel_styles(worksheet, df):
 
 
 class ExcelWriter:
-    """Lightweight Excel writer used in tests."""
+    """Write Excel files with status-based color coding."""
 
     def __init__(self, path: str, headers: list[str]):
         self.path = path

--- a/tests/test_excel_writer.py
+++ b/tests/test_excel_writer.py
@@ -1,0 +1,22 @@
+import os
+from tempfile import TemporaryDirectory
+import pytest
+
+from excel_generator import ExcelWriter, NEEDS_REVIEW_FILL, FAILED_FILL
+
+
+def test_excel_writer_row_colors():
+    with TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, 'out.xlsx')
+        headers = ['processing_status', 'Title']
+        writer = ExcelWriter(path, headers)
+        writer.add_row({'processing_status': 'Needs Review', 'Title': 'One'})
+        writer.add_row({'processing_status': 'Failed', 'Title': 'Two'})
+        writer.save()
+
+        import openpyxl
+        wb = openpyxl.load_workbook(path)
+        ws = wb.active
+        # Row colors should match status
+        assert ws['A2'].fill.start_color.rgb == NEEDS_REVIEW_FILL.start_color.rgb
+        assert ws['A3'].fill.start_color.rgb == FAILED_FILL.start_color.rgb


### PR DESCRIPTION
## Summary
- remove redundant ExcelWriter classes
- keep single ExcelWriter with color-coding logic
- add regression test for ExcelWriter row styling

## Testing
- `python -m py_compile excel_generator.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686227c4ed84832eac0f4289c2dcc6cb