### PR TITLE
Add needs_review dir handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ KYO_QA_ServiceNow_Knowledge_Tool_v25.1.0/\
 ├── python-3.11.9/ (optional, for portable Python)\
 ├── logs/ (auto-created)\
 ├── output/ (auto-created)\
-└── PDF_TXT/ (auto-created)
+└── PDF_TXT/
+    └── needs_review/ (auto-created)
 
 ## Directory Breakdown
 
-This tool extracts model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`, `ECOSYS A123abcd`), QA/SB numbers, and descriptions from Kyocera QA/service PDFs using OCR and pattern recognition. It updates blank cells in the “Meta” column of a cloned ServiceNow-compatible Excel file, preserving the original. Text files for documents needing review are saved in `PDF_TXT`. No PDFs are retained.
+This tool extracts model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`, `ECOSYS A123abcd`), QA/SB numbers, and descriptions from Kyocera QA/service PDFs using OCR and pattern recognition. It updates blank cells in the “Meta” column of a cloned ServiceNow-compatible Excel file, preserving the original. Text files for documents needing review are saved in `PDF_TXT/needs_review`. No PDFs are retained.
 
 ## 📁 Key Files
 
@@ -76,7 +77,7 @@ This tool extracts model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`, `ECOSY
 | --- | --- |
 | `/logs/` | Session logs (success/fail) |
 | `/output/` | Excel output (`cloned_<excel>.xlsx`) |
-| `/PDF_TXT/` | Text files for documents needing review |
+| `/PDF_TXT/needs_review/` | Text files for documents needing review |
 | `/venv/` | Virtual environment for isolation |
 
 ## ✅ Summary
@@ -84,7 +85,7 @@ This tool extracts model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`, `ECOSY
 - **Secure**: No PDF retention.
 - **Automated**: Auto-installs dependencies.
 - **Portable**: Supports portable Python and Tesseract for USB deployment.
-- **Modular & Logged**: Comprehensive logging to `/logs/` and `PDF_TXT` for review.
+ - **Modular & Logged**: Comprehensive logging to `/logs/` and `PDF_TXT/needs_review` for review.
 - **UI**: Bright, Kyocera-branded Tkinter UI with progress bars, color-coded logs, and detailed processing feedback.
 - **Excel**: Clones input Excel, updates only blank “Meta” cells with model numbers.
 
@@ -117,8 +118,8 @@ This tool extracts model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`, `ECOSY
 4. Click "Start Processing" to:
    - Extract model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`), QA numbers, and metadata.
    - Update blank “Meta” cells in a cloned Excel file.
-   - Save text files for failed or incomplete extractions in `PDF_TXT`.
-5. Review output in `/output/cloned_<excel>.xlsx` and logs in `/logs/` or `PDF_TXT`.
+    - Save text files for failed or incomplete extractions in `PDF_TXT/needs_review`.
+ 5. Review output in `/output/cloned_<excel>.xlsx` and logs in `/logs/` or `PDF_TXT/needs_review`.
 
 ### 5. Development and Testing
 
@@ -144,7 +145,7 @@ Requires `pandas`, `PyMuPDF`, `PySide6`, `openpyxl`, `pytesseract`, `python-date
 
 - Session logs in `/logs/[YYYY-MM-DD_HH-MM-SS]_session.log`.
 - Success/failure logs as `[YYYYMMDD]_SUCCESSlog.md` or `FAILlog.md` in `/logs/`.
-- Text files for documents needing review (e.g., failed model extraction) in `/PDF_TXT/*.txt`.
+ - Text files for documents needing review (e.g., failed model extraction) in `/PDF_TXT/needs_review/*.txt`.
 
 ### 8. Portable Deployment
 

--- a/config.py
+++ b/config.py
@@ -6,6 +6,7 @@ BASE_DIR = Path(__file__).parent
 OUTPUT_DIR = BASE_DIR / "output"
 LOGS_DIR = BASE_DIR / "logs"
 PDF_TXT_DIR = BASE_DIR / "PDF_TXT"
+NEEDS_REVIEW_DIR = PDF_TXT_DIR / "needs_review"
 CACHE_DIR = BASE_DIR / ".cache"
 
 # --- BRANDING AND UI ---

--- a/file_utils.py
+++ b/file_utils.py
@@ -15,6 +15,7 @@ REQUIRED_FOLDERS = [
     "logs",
     "output",
     "PDF_TXT",
+    "PDF_TXT/needs_review",
     "temp"
     # add more as needed
 ]

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -13,10 +13,12 @@ from file_utils import is_file_locked
 from ocr_utils import extract_text_from_pdf, _is_ocr_needed
 
 def clear_review_folder():
-    if PDF_TXT_DIR.exists():
-        for f in PDF_TXT_DIR.glob("*.txt"):
-            try: f.unlink()
-            except OSError as e: print(f"Error deleting review file {f}: {e}")
+    if NEEDS_REVIEW_DIR.exists():
+        for f in NEEDS_REVIEW_DIR.glob("*.txt"):
+            try:
+                f.unlink()
+            except OSError as e:
+                print(f"Error deleting review file {f}: {e}")
 
 def get_cache_path(pdf_path):
     try: return CACHE_DIR / f"{pdf_path.stem}_{pdf_path.stat().st_size}.json"
@@ -52,9 +54,16 @@ def process_single_pdf(pdf_path, progress_queue, ignore_cache=False):
         data = harvest_all_data(extracted_text, filename)
         if data["models"] == "Not Found":
             status = "Needs Review"
-            review_txt_path = PDF_TXT_DIR / f"{filename}.txt"
-            with open(review_txt_path, 'w', encoding='utf-8') as f: f.write(f"--- Filename: {filename} ---\n\n{extracted_text}")
-            review_info = {"filename": filename, "reason": "No models", "txt_path": str(review_txt_path), "pdf_path": str(pdf_path)}
+            NEEDS_REVIEW_DIR.mkdir(parents=True, exist_ok=True)
+            review_txt_path = NEEDS_REVIEW_DIR / f"{filename}.txt"
+            with open(review_txt_path, 'w', encoding='utf-8') as f:
+                f.write(f"--- Filename: {filename} ---\n\n{extracted_text}")
+            review_info = {
+                "filename": filename,
+                "reason": "No models",
+                "txt_path": str(review_txt_path),
+                "pdf_path": str(pdf_path),
+            }
             progress_queue.put({"type": "review_item", "data": review_info})
         else:
             status = "Pass"; review_info = None

--- a/tests/test_review_folder.py
+++ b/tests/test_review_folder.py
@@ -1,0 +1,46 @@
+import os
+from queue import Queue
+from pathlib import Path
+import sys
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+fake_styles = types.ModuleType("openpyxl.styles")
+fake_styles.PatternFill = object
+fake_styles.Alignment = object
+fake_utils = types.ModuleType("openpyxl.utils")
+fake_utils.get_column_letter = lambda x: "A"
+fake_openpyxl = types.ModuleType("openpyxl")
+fake_openpyxl.styles = fake_styles
+fake_openpyxl.utils = fake_utils
+sys.modules.setdefault("openpyxl.styles", fake_styles)
+sys.modules.setdefault("openpyxl.utils", fake_utils)
+sys.modules.setdefault("openpyxl", fake_openpyxl)
+sys.modules.setdefault("fitz", types.ModuleType("fitz"))
+pe = __import__("processing_engine")
+
+def test_clear_review_folder(tmp_path, monkeypatch):
+    review_dir = tmp_path / "needs_review"
+    review_dir.mkdir(parents=True)
+    for i in range(3):
+        (review_dir / f"file{i}.txt").write_text("dummy")
+    monkeypatch.setattr(pe, "NEEDS_REVIEW_DIR", review_dir)
+    pe.clear_review_folder()
+    assert not any(review_dir.glob("*.txt"))
+
+
+def test_process_single_pdf_saves_review(tmp_path, monkeypatch):
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_text("pdf")
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    review_dir = tmp_path / "needs_review"
+    monkeypatch.setattr(pe, "NEEDS_REVIEW_DIR", review_dir)
+    monkeypatch.setattr(pe, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(pe, "extract_text_from_pdf", lambda p: "dummy text")
+    monkeypatch.setattr(pe, "_is_ocr_needed", lambda p: False)
+    monkeypatch.setattr(pe, "harvest_all_data", lambda text, filename: {"models": "Not Found", "author": ""})
+    q = Queue()
+    result = pe.process_single_pdf(pdf, q, ignore_cache=True)
+    assert result["status"] == "Needs Review"
+    assert (review_dir / f"{pdf.name}.txt").exists()


### PR DESCRIPTION
## Summary
- introduce `NEEDS_REVIEW_DIR` path constant
- save review TXT files under `PDF_TXT/needs_review/`
- clear only this subfolder on rescan
- auto-create the subfolder
- document new location in README
- test review-folder logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686227be4b14832eaca490cb0aef3c46