### PR TITLE
Fix custom pattern duplication

### DIFF
--- a/custom_patterns.py
+++ b/custom_patterns.py
@@ -9,8 +9,6 @@ MODEL_PATTERNS = [
     r"\\bVi\\d+\\b",
     r"\\bKM-\\d+\\b",
     r"\\bFS-\\d+DN\\b",
-    r"\\bFS-\\d+DN\\b",
-    r"\\bFS-\\d+DN\\b",
     r"\\bP\\d+dn\\b",
     r"\\bM\\d+dn\\b",
     r"\\bM\\d+cdn\\b",

--- a/tests/test_custom_patterns.py
+++ b/tests/test_custom_patterns.py
@@ -1,0 +1,20 @@
+import importlib
+import unittest
+
+import custom_patterns
+from data_harvesters import get_combined_patterns
+from config import MODEL_PATTERNS as DEFAULT_MODEL_PATTERNS
+
+class PatternLoadingTests(unittest.TestCase):
+    def test_loader_returns_unique_patterns(self):
+        # Reload to ensure latest version is used
+        importlib.reload(custom_patterns)
+        patterns = get_combined_patterns("MODEL_PATTERNS", DEFAULT_MODEL_PATTERNS)
+        self.assertEqual(
+            patterns[:len(custom_patterns.MODEL_PATTERNS)],
+            custom_patterns.MODEL_PATTERNS,
+        )
+        self.assertEqual(len(patterns), len(set(patterns)))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep only unique values in `MODEL_PATTERNS`
- test that pattern loader keeps custom order and removes duplicates

## Testing
- `python -m py_compile custom_patterns.py data_harvesters.py tests/test_custom_patterns.py`
- `python -m unittest tests/test_custom_patterns.py -v`


------
https://chatgpt.com/codex/tasks/task_e_686227b7ac10832ebe102db7829a8c7d