### PR TITLE
Fix packaging version naming

### DIFF
--- a/packaging_script.py
+++ b/packaging_script.py
@@ -1,12 +1,8 @@
 # KYO QA Packaging Script
-import os
 import zipfile
 from datetime import datetime
 from pathlib import Path
 from version import get_version
-
-# Use central version definition
-from version import VERSION
 
 # Paths
 project_root = Path(__file__).parent
@@ -14,9 +10,9 @@ output_dir = project_root / "dist"
 output_dir.mkdir(exist_ok=True)
 
 # Metadata
-VERSION = get_version()
+current_version = get_version()
 ts = datetime.now().strftime("%Y%m%d_%H%M")
-out_zip = output_dir / f"KYO_QA_Knowledge_Tool_{VERSION}_{ts}.zip"
+out_zip = output_dir / f"KYO_QA_Knowledge_Tool_{current_version}_{ts}.zip"
 
 # Files and folders to include
 include = [

--- a/tests/test_packaging_script.py
+++ b/tests/test_packaging_script.py
@@ -1,0 +1,8 @@
+import importlib
+import packaging_script
+from version import VERSION as APP_VERSION
+
+def test_zip_filename_contains_current_version():
+    importlib.reload(packaging_script)
+    assert packaging_script.current_version == APP_VERSION
+    assert packaging_script.out_zip.name.startswith(f"KYO_QA_Knowledge_Tool_{APP_VERSION}")


### PR DESCRIPTION
## Summary
- prevent shadowing of VERSION constant in `packaging_script.py`
- test that zip name uses the application version

## Testing
- `ruff check packaging_script.py tests/test_packaging_script.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686227b5a94c832e8e237ddf3d724f20