### PR TITLE
Audit fixes and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # KYO QA ServiceNow Knowledge Tool v25.1.0
 
+## Current Version
+
+v25.1.0
+
 ## How to Set Up and Run (Modular, Fully Logged)
 
 ### 1. Prerequisites
@@ -119,7 +123,13 @@ This tool extracts model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`, `ECOSY
    - Extract model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`), QA numbers, and metadata.
    - Update blank “Meta” cells in a cloned Excel file.
    - Save text files for failed or incomplete extractions in `PDF_TXT/needs_review`.
- 5. Review output in `/output/cloned_<excel>.xlsx` and logs in `/logs/` or `PDF_TXT/needs_review`.
+5. Review output in `/output/cloned_<excel>.xlsx` and logs in `/logs/` or `PDF_TXT/needs_review`.
+
+### Custom Pattern Filtering and Rescan
+
+- Click **Patterns** in the main window to edit regex filters stored in `custom_patterns.py`.
+- Use **Re-run Flagged** to process files from the `PDF_TXT/needs_review` folder again.
+- Both custom and built-in patterns are applied during each run.
 
 ### 5. Development and Testing
 

--- a/tests/test_processing_engine.py
+++ b/tests/test_processing_engine.py
@@ -37,3 +37,25 @@ def test_process_folder_invokes_run(tmp_path):
     assert called['info']['input_path'] == tmp_path
 
 
+def test_process_zip_archive_invokes_run(tmp_path):
+    excel = tmp_path / "base.xlsx"
+    excel.touch()
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_text("pdf")
+    zip_path = tmp_path / "docs.zip"
+    import zipfile
+    with zipfile.ZipFile(zip_path, 'w') as zf:
+        zf.write(pdf, pdf.name)
+
+    called = {}
+
+    def dummy_run(job_info, queue, cancel, pause):
+        called['info'] = job_info
+
+    with mock.patch('processing_engine.run_processing_job', dummy_run):
+        processing_engine.process_zip_archive(zip_path, excel)
+
+    assert called['info']['excel_path'] == excel
+
+
+


### PR DESCRIPTION
## Summary
- add missing processing_folder utilities
- include tests for archive helper
- document current version and pattern rescan process

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_processing_engine.py::test_process_folder_invokes_run -q`
- `pytest tests/test_processing_engine.py::test_process_zip_archive_invokes_run -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863282817d0832ea315f4d3a97338ff