### PR TITLE
Add configurable console logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ The CLI currently relies on the upcoming `process_folder` and `process_zip_archi
 - Session logs in `/logs/[YYYY-MM-DD_HH-MM-SS]_session.log`.
 - Success/failure logs as `[YYYYMMDD]_SUCCESSlog.md` or `FAILlog.md` in `/logs/`.
 - Text files for documents needing review (e.g., failed model extraction) in `/PDF_TXT/needs_review/*.txt`.
+- To also print log messages to the console, call `setup_logger` with `to_console=True`:
+  ```python
+  from logging_utils import setup_logger
+  logger = setup_logger("cli", to_console=True)
+  ```
 
 ### 9. Portable Deployment
 

--- a/cli_runner.py
+++ b/cli_runner.py
@@ -7,7 +7,7 @@ from processing_engine import process_folder, process_zip_archive
 from logging_utils import setup_logger
 from file_utils import ensure_folders
 
-logger = setup_logger("cli")
+logger = setup_logger("cli", to_console=True)
 
 def timestamped_copy(filepath):
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,37 @@
+import logging
+
+import logging_utils
+
+
+def test_setup_logger_to_console_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(logging_utils, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(logging_utils, "SESSION_LOG_FILE", tmp_path / "session.log")
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+
+    initial_streams = sum(
+        1
+        for h in root_logger.handlers
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+    )
+
+    logging_utils.setup_logger("no_console")
+    after_no_console = sum(
+        1
+        for h in root_logger.handlers
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+    )
+
+    root_logger.handlers.clear()
+
+    logging_utils.setup_logger("with_console", to_console=True)
+    after_console = sum(
+        1
+        for h in root_logger.handlers
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+    )
+
+    assert after_no_console == initial_streams
+    assert after_console >= after_no_console + 1
+


### PR DESCRIPTION
## Summary
- add `to_console` flag to `logging_utils.setup_logger`
- route CLI logs to console
- document console logging in README
- test console flag logic

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864875f303c832eaa998fc7f0a0b49e