### PR TITLE
Remove Live Terminal feature

### DIFF
--- a/gui_components.py
+++ b/gui_components.py
@@ -106,13 +106,3 @@ def create_status_and_log_section(parent, app):
     log_scroll.grid(row=0, column=1, sticky="ns")
     app.log_text.config(yscrollcommand=log_scroll.set)
     
-    terminal_tab = ttk.Frame(notebook, padding=10)
-    notebook.add(terminal_tab, text="Live Terminal")
-    terminal_tab.rowconfigure(0, weight=1)
-    terminal_tab.columnconfigure(0, weight=1)
-    
-    app.terminal_text = tk.Text(terminal_tab, wrap=tk.WORD, state=tk.DISABLED, background="black", foreground="#E0E0E0", font=("Consolas", 10), insertbackground="white")
-    app.terminal_text.grid(row=0, column=0, sticky="nsew")
-    term_scroll = ttk.Scrollbar(terminal_tab, command=app.terminal_text.yview)
-    term_scroll.grid(row=0, column=1, sticky="ns")
-    app.terminal_text.config(yscrollcommand=term_scroll.set)

--- a/tests/test_text_redirector.py
+++ b/tests/test_text_redirector.py
@@ -1,0 +1,26 @@
+import queue
+import sys
+import types
+
+# Stub heavy dependencies to import kyo_qa_tool_app without installing them
+openpyxl_stub = types.ModuleType('openpyxl')
+openpyxl_stub.styles = types.ModuleType('openpyxl.styles')
+openpyxl_stub.utils = types.ModuleType('openpyxl.utils')
+openpyxl_stub.styles.PatternFill = object
+openpyxl_stub.utils.get_column_letter = lambda x: 'A'
+sys.modules.setdefault('openpyxl', openpyxl_stub)
+sys.modules.setdefault('openpyxl.styles', openpyxl_stub.styles)
+sys.modules.setdefault('openpyxl.utils', openpyxl_stub.utils)
+sys.modules.setdefault('fitz', types.ModuleType('fitz'))
+sys.modules.setdefault('cv2', types.ModuleType('cv2'))
+sys.modules.setdefault('numpy', types.ModuleType('numpy'))
+sys.modules.setdefault('pytesseract', types.ModuleType('pytesseract'))
+
+from kyo_qa_tool_app import TextRedirector  # noqa: E402
+
+
+def test_text_redirector_write():
+    q = queue.Queue()
+    tr = TextRedirector(q)
+    tr.write("hello")
+    assert q.get_nowait() == "hello"


### PR DESCRIPTION
## Summary
- drop the Live Terminal tab from the GUI
- simplify `KyoQAToolApp` init by removing stdout redirection
- cut out the unused `process_terminal_queue`
- add a small test for `TextRedirector`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686487631a4c832eb9c16bb1f104fd98