### PR TITLE
Add OCR failure retry workflow

### DIFF
--- a/gui_components.py
+++ b/gui_components.py
@@ -46,6 +46,15 @@ def create_process_controls(parent, app):
     # --- FIX: Restored the missing 'Patterns' and 'Exit' buttons ---
     app.review_btn = ttk.Button(ctrl, text=" Patterns", image=app.patterns_icon, compound="left", command=app.open_pattern_manager)
     app.review_btn.grid(row=2, column=0, sticky="ew", pady=2)
+    app.retry_ocr_btn = ttk.Button(
+        ctrl,
+        text=" Retry OCR",
+        image=app.rerun_icon,
+        compound="left",
+        command=app.retry_failed_ocr,
+        state=tk.DISABLED,
+    )
+    app.retry_ocr_btn.grid(row=2, column=1, sticky="ew", padx=5, pady=2)
     app.exit_btn = ttk.Button(ctrl, text=" Exit", image=app.exit_icon, compound="left", command=app.on_closing)
     app.exit_btn.grid(row=2, column=3, sticky="ew", pady=2)
 

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -50,6 +50,7 @@ class KyoQAToolApp(tk.Tk):
         self.is_paused = False
         self.result_file_path = None
         self.reviewable_files = []
+        self.ocr_failed_files = []
         self.start_time = None
         self.last_run_info = {}
         self.response_queue = queue.Queue()
@@ -248,6 +249,45 @@ class KyoQAToolApp(tk.Tk):
         self.log_message(f"Re-running {len(files)} flagged files...", "info")
         self.start_processing(job={"excel_path": self.result_file_path, "input_path": files}, is_rerun=True)
 
+    def _resolve_failed_file(self, filename: str):
+        """Return full path for a failed OCR file."""
+        folder = self.selected_folder.get()
+        if folder:
+            path = Path(folder) / filename
+            if path.exists():
+                return str(path)
+        for f in self.selected_files_list:
+            if Path(f).name == filename:
+                return f
+        return None
+
+    def retry_failed_ocr(self):
+        if not self.ocr_failed_files:
+            messagebox.showinfo("No OCR Failures", "There are no OCR failures to retry.")
+            self.retry_ocr_btn.config(state=tk.DISABLED)
+            return
+        filename = self.ocr_failed_files.pop(0)
+        file_path = self._resolve_failed_file(filename)
+        if not file_path:
+            messagebox.showerror("File Not Found", f"Could not locate {filename}.")
+            return
+        self.log_message(f"Retrying OCR for {filename}", "info")
+        q = queue.Queue()
+        result = process_single_pdf(file_path, q, ignore_cache=True)
+        while not q.empty():
+            msg = q.get()
+            if msg.get("type") == "log":
+                self.log_message(msg.get("msg", ""), msg.get("tag", "info"))
+        if result and result.get("status") != "Fail":
+            messagebox.showinfo("Success", f"OCR succeeded for {filename}.")
+            self.log_message(f"OCR retry succeeded for {filename}", "success")
+        else:
+            messagebox.showerror("Retry Failed", f"OCR failed again for {filename}.")
+            self.log_message(f"OCR retry failed for {filename}", "error")
+            self.ocr_failed_files.append(filename)
+        if not self.ocr_failed_files:
+            self.retry_ocr_btn.config(state=tk.DISABLED)
+
     def browse_excel(self):
         path = filedialog.askopenfilename(title="Select Excel Template", filetypes=[("Excel Files", "*.xlsx *.xlsm"), ("All Files", "*.*")])
         if path:
@@ -362,6 +402,7 @@ class KyoQAToolApp(tk.Tk):
             var.set(0)
         self.reviewable_files.clear()
         self.review_tree.delete(*self.review_tree.get_children())
+        self.ocr_failed_files.clear()
         self.process_btn.config(state=tk.DISABLED)
         self.pause_btn.config(state=tk.NORMAL, text=" Pause")
         self.stop_btn.config(state=tk.NORMAL)
@@ -369,6 +410,7 @@ class KyoQAToolApp(tk.Tk):
         self.open_result_btn.config(state=tk.DISABLED)
         self.exit_btn.config(state=tk.DISABLED)
         self.rerun_btn.config(state=tk.DISABLED)
+        self.retry_ocr_btn.config(state=tk.DISABLED)
         self.review_file_btn.config(state=tk.DISABLED)
         self.status_current_file.set("Initializing...")
         self.time_remaining_var.set("Calculating...")
@@ -390,6 +432,8 @@ class KyoQAToolApp(tk.Tk):
             self.open_result_btn.config(state=tk.NORMAL)
         if self.reviewable_files:
             self.rerun_btn.config(state=tk.NORMAL)
+        if self.ocr_failed_files:
+            self.retry_ocr_btn.config(state=tk.NORMAL)
         final_status = "Complete" if status == "Complete" else "Error"
         self.status_current_file.set(f"Job {status}")
         self.time_remaining_var.set("Done!")
@@ -452,6 +496,12 @@ class KyoQAToolApp(tk.Tk):
                     data = msg.get("data", {})
                     self.reviewable_files.append(data)
                     self.review_tree.insert('', 'end', values=(data.get('filename', 'Unknown'),))
+                elif mtype == "ocr_failed":
+                    fname = msg.get("file")
+                    if fname:
+                        self.ocr_failed_files.append(fname)
+                        self.retry_ocr_btn.config(state=tk.NORMAL)
+                        self.log_message(f"OCR failed for {fname}.", "error")
                 elif mtype == "result_path":
                     self.result_file_path = msg.get("path")
                 elif mtype == "finish":

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -76,7 +76,15 @@ def process_single_pdf(pdf_path, progress_queue, ignore_cache=False):
     
     extracted_text = extract_text_from_pdf(absolute_pdf_path)
     if not extracted_text.strip():
-        result = {"filename": filename, "models": "Error: Text Extraction Failed", "author": "", "status": "Fail", "ocr_used": ocr_required, "review_info": None}
+        progress_queue.put({"type": "ocr_failed", "file": filename})
+        result = {
+            "filename": filename,
+            "models": "Error: Text Extraction Failed",
+            "author": "",
+            "status": "Fail",
+            "ocr_used": ocr_required,
+            "review_info": None,
+        }
     else:
         progress_queue.put({"type": "status", "msg": filename, "led": "AI"})
         data = harvest_all_data(extracted_text, filename)

--- a/tests/test_processing_engine.py
+++ b/tests/test_processing_engine.py
@@ -1,0 +1,46 @@
+import queue
+from pathlib import Path
+import sys
+import types
+
+# Stub dependencies not available in the test environment
+fake_ocr_utils = types.ModuleType("ocr_utils")
+fake_ocr_utils.extract_text_from_pdf = lambda p: ""
+fake_ocr_utils._is_ocr_needed = lambda p: False
+sys.modules["ocr_utils"] = fake_ocr_utils
+
+fake_openpyxl = types.ModuleType("openpyxl")
+fake_openpyxl.load_workbook = lambda *a, **k: None
+
+styles_mod = types.ModuleType("openpyxl.styles")
+styles_mod.PatternFill = lambda **kw: None
+sys.modules["openpyxl.styles"] = styles_mod
+
+utils_ex = types.ModuleType("openpyxl.utils.exceptions")
+utils_ex.InvalidFileException = Exception
+sys.modules["openpyxl.utils.exceptions"] = utils_ex
+
+utils_mod = types.ModuleType("openpyxl.utils")
+utils_mod.exceptions = utils_ex
+utils_mod.get_column_letter = lambda x: "A"
+sys.modules["openpyxl.utils"] = utils_mod
+
+fake_openpyxl.styles = styles_mod
+fake_openpyxl.utils = utils_mod
+sys.modules["openpyxl"] = fake_openpyxl
+
+import processing_engine
+
+
+def test_process_single_pdf_ocr_failed(tmp_path, monkeypatch):
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_text("dummy")
+    monkeypatch.setattr(processing_engine, "extract_text_from_pdf", lambda p: "")
+    monkeypatch.setattr(processing_engine, "_is_ocr_needed", lambda p: True)
+    q = queue.Queue()
+    result = processing_engine.process_single_pdf(pdf, q)
+    msgs = []
+    while not q.empty():
+        msgs.append(q.get())
+    assert result["status"] == "Fail"
+    assert any(m.get("type") == "ocr_failed" for m in msgs)


### PR DESCRIPTION
## Summary
- flag OCR failures in `process_single_pdf`
- queue handler enables a **Retry OCR** button
- add helper to retry OCR extraction for failed files
- include new control in the GUI
- test OCR failure path in `process_single_pdf`

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864875cf368832e9e797d86ff3b15b0