### PR TITLE
Fix OCR fallback and update tests

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -24,20 +24,7 @@ logger = logging_utils.setup_logger("app")
 
 # Class to redirect stdout/stderr to a queue for UI display
 class TextRedirector:
-    def __init__(self, widget_queue):
-        self.widget_queue = widget_queue
-
-    def write(self, s):
-        self.widget_queue.put(s)
-
-    def flush(self):
-        """Flush is required for file-like objects; it's a no-op here."""
-        pass
-
-
-class TextRedirector:
-
-    """Simple stdout redirector used in testing."""
+    """Redirect stdout/stderr messages to a queue."""
 
     def __init__(self, queue_obj):
         self.queue = queue_obj
@@ -46,7 +33,7 @@ class TextRedirector:
         self.queue.put(string)
 
     def flush(self):
-
+        """Required for file-like interfaces; no action needed."""
         pass
 
 class KyoQAToolApp(tk.Tk):

--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -103,7 +103,8 @@ def extract_text_from_pdf(pdf_path):
         if TESSERACT_AVAILABLE:
             log_info(logger, f"Attempting OCR on {pdf_path.name}")
             ocr_text = extract_text_with_ocr(pdf_path)
-            return ocr_text if ocr_text.strip() else "[NO TEXT EXTRACTED]"
+            # Return empty string if OCR fails to extract text
+            return ocr_text if ocr_text.strip() else ""
         
         log_warning(logger, f"No text found in {pdf_path.name} and OCR is not available.")
         raise PDFExtractionError("No text could be extracted and OCR is unavailable.")

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -82,7 +82,8 @@ def process_single_pdf(pdf_path, progress_queue, ignore_cache=False):
 
         if ocr_required and not extracted_text.strip():
             progress_queue.put({"type": "ocr_failed"})
-            status = "Fail"
+            # Mark for review if OCR produced no output
+            status = "Needs Review"
             reason = "No text extracted via OCR"
             data = {"models": "Not Found", "author": ""}
         else:

--- a/tests/test_processing_engine.py
+++ b/tests/test_processing_engine.py
@@ -44,6 +44,7 @@ def test_process_single_pdf_ocr_failed(tmp_path, monkeypatch):
     monkeypatch.setattr(processing_engine, "_is_ocr_needed", lambda p: True)
     q = queue.Queue()
     result = processing_engine.process_single_pdf(pdf, q)
+    msgs = []
     while not q.empty():
         msgs.append(q.get())
     assert result["status"] == "Needs Review"


### PR DESCRIPTION
## Summary
- consolidate `TextRedirector` class in UI module
- return empty string when OCR fails to extract text
- mark PDFs with failed OCR as `Needs Review`
- fix test for progress queue messages

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864bdd6a9ec832e8a6c6dd1b0d40b7b