### PR TITLE
Fix startup failure due to missing get_version

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,4 @@
+import version
+
+def test_get_version():
+    assert version.get_version() == version.VERSION

--- a/version.py
+++ b/version.py
@@ -1,2 +1,8 @@
 # version.py
 VERSION = "25.1.0"
+
+
+def get_version() -> str:
+    """Return the current application version string."""
+    return VERSION
+


### PR DESCRIPTION
## Summary
- reintroduce `get_version` helper in `version.py`
- add a simple test for the helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864cc234be4832ebb6bcb8d5fcc072f