### PR TITLE
Update logging dir to use config constant

### DIFF
--- a/logging_utils.py
+++ b/logging_utils.py
@@ -2,11 +2,11 @@
 from version import VERSION
 import logging
 import sys
-from pathlib import Path
+from config import LOGS_DIR
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
-LOG_DIR = Path.cwd() / "logs"
+LOG_DIR = LOGS_DIR
 LOG_DIR.mkdir(exist_ok=True)
 
 SESSION_LOG_FILE = LOG_DIR / f"{datetime.now():%Y-%m-%d_%H-%M-%S}_session.log"

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,10 +1,14 @@
 import logging
-
-import logging_utils
+import importlib
+import config
 
 
 def test_setup_logger_to_console_flag(tmp_path, monkeypatch):
-    monkeypatch.setattr(logging_utils, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(config, "LOGS_DIR", tmp_path)
+
+    import logging_utils
+    importlib.reload(logging_utils)
+
     monkeypatch.setattr(logging_utils, "SESSION_LOG_FILE", tmp_path / "session.log")
 
     root_logger = logging.getLogger()


### PR DESCRIPTION
## Summary
- reuse `LOGS_DIR` from `config` in logging utilities
- patch `config.LOGS_DIR` in logger tests to allow reload

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864cdd8dab4832e91e48bd0cd476356