### PR TITLE
Fix packaging include list

### DIFF
--- a/packaging_script.py
+++ b/packaging_script.py
@@ -32,7 +32,6 @@ include = [
     "README.md",
     "requirements.txt",
     "Sample_Set",
-    "extract",
     "tests",
 ]
 

--- a/tests/test_packaging_script.py
+++ b/tests/test_packaging_script.py
@@ -1,0 +1,13 @@
+import zipfile
+
+import packaging_script
+
+
+def test_zip_project_creates_archive(tmp_path, monkeypatch):
+    tmp_zip = tmp_path / 'test.zip'
+    monkeypatch.setattr(packaging_script, 'out_zip', tmp_zip)
+    monkeypatch.setattr(packaging_script, 'include', ['version.py'])
+    packaging_script.zip_project()
+    assert tmp_zip.exists()
+    with zipfile.ZipFile(tmp_zip) as z:
+        assert 'version.py' in z.namelist()


### PR DESCRIPTION
## Summary
- drop nonexistent `extract` directory from packaging script
- add a regression test for packaging

## Testing
- `ruff check .`
- `pytest -q`
- `python packaging_script.py`


------
https://chatgpt.com/codex/tasks/task_e_6864cf89bba4832e92ee8c1dac73225b