### PR TITLE
Improve venv bootstrap with pip check

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This tool extracts model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`, `ECOSY
 1. Place all files in a folder (e.g., `KYO_QA_ServiceNow_Knowledge_Tool_v25.1.0`).
 2. Install Python 3.11.x or place portable Python in `python-3.11.9`. Optionally, install Tesseract or place in `tesseract` folder.
 3. Run `START.bat` (Windows) or `python run.py`:
-   - Sets up `/venv/` and installs dependencies from `requirements.txt`.
+   - Sets up `/venv/`, bootstrapping `pip` if needed, and installs dependencies from `requirements.txt`.
    - Outputs logs to `/logs/` and Excel to `/output/`.
 4. Manual setup (if needed):
 

--- a/run.py
+++ b/run.py
@@ -65,6 +65,23 @@ def run_command_with_spinner(command, message):
         sys.stdout.write(f"\r{Colors.RED}✗{Colors.ENDC} {message}... Failed.\n")
         return False
 
+
+def ensure_pip(venv_python: Path) -> bool:
+    """Ensure pip is available in the virtual environment."""
+    try:
+        subprocess.check_call(
+            [str(venv_python), "-m", "pip", "--version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("[INFO] Installing pip in the venv...")
+        return run_command_with_spinner(
+            [str(venv_python), "-m", "ensurepip", "--upgrade"],
+            "Bootstrapping pip",
+        )
+
 def get_venv_python_path():
     """Gets the path to the Python executable in the virtual environment."""
     return VENV_DIR / "Scripts" / "python.exe" if sys.platform == "win32" else VENV_DIR / "bin" / "python"
@@ -84,9 +101,13 @@ def setup_environment():
             shutil.rmtree(VENV_DIR)
         if not run_command_with_spinner([sys.executable, "-m", "venv", str(VENV_DIR)], "Creating venv folder"):
             return False
+    if not ensure_pip(venv_python):
+        return False
+    if not (VENV_DIR / "installed.flag").exists():
         print("[INFO] Installing dependencies (this may take a few minutes)...")
         if not run_command_with_spinner([str(venv_python), "-m", "pip", "install", "-r", str(REQUIREMENTS_FILE)], "Installing packages"):
             return False
+        (VENV_DIR / "installed.flag").touch()
     
     print(f"{Colors.GREEN}✓ Environment is ready.{Colors.ENDC}")
     return True

--- a/tests/test_run_setup.py
+++ b/tests/test_run_setup.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import run
+
+
+def test_ensure_pip_installed(monkeypatch):
+    called = {}
+    def fake_check_call(cmd, stdout=None, stderr=None):
+        called['cmd'] = cmd
+    monkeypatch.setattr(run.subprocess, 'check_call', fake_check_call)
+    assert run.ensure_pip(Path('py'))
+    assert called['cmd'][1:] == ['-m', 'pip', '--version']
+
+
+def test_ensure_pip_bootstrap(monkeypatch):
+    def raise_error(*a, **k):
+        raise FileNotFoundError
+    monkeypatch.setattr(run.subprocess, 'check_call', raise_error)
+    called = {}
+    def fake_spinner(cmd, msg):
+        called['cmd'] = cmd
+        return True
+    monkeypatch.setattr(run, 'run_command_with_spinner', fake_spinner)
+    assert run.ensure_pip(Path('py'))
+    assert 'ensurepip' in called['cmd']


### PR DESCRIPTION
## Summary
- add `ensure_pip` helper to verify pip in the new venv
- call helper from `setup_environment`
- note pip bootstrapping in README
- test ensure_pip logic

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d491d4d8832ea65b66500af766ec