### PR TITLE
Add OCR failure segregation and review folder button

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,11 @@ from pathlib import Path
 BASE_DIR = Path(__file__).parent
 OUTPUT_DIR = BASE_DIR / "output"
 LOGS_DIR = BASE_DIR / "logs"
-PDF_TXT_DIR = BASE_DIR / "PDF_TXT"
+# Directory containing PDFs that need manual review
+NEED_REVIEW_DIR = BASE_DIR / "NEED_REVIEW"
+# Directory for PDFs where OCR or translation completely failed
+OCR_FAILED_DIR = BASE_DIR / "OCR_FAILED"
+PDF_TXT_DIR = NEED_REVIEW_DIR  # backward compatibility
 CACHE_DIR = BASE_DIR / ".cache"
 ASSETS_DIR = BASE_DIR / "assets" # For icons
 

--- a/gui_components.py
+++ b/gui_components.py
@@ -50,6 +50,15 @@ def create_process_controls(parent, app):
     
     app.fullscreen_btn = ttk.Button(ctrl, text=" Fullscreen", image=app.fullscreen_icon, compound="left", command=app.toggle_fullscreen)
     app.fullscreen_btn.grid(row=2, column=1, sticky="ew", pady=2)
+
+    app.open_review_btn = ttk.Button(
+        ctrl,
+        text=" Open Review Folder",
+        image=app.open_icon,
+        compound="left",
+        command=app.open_review_folder,
+    )
+    app.open_review_btn.grid(row=2, column=2, sticky="ew", pady=2)
     
     app.exit_btn = ttk.Button(ctrl, text=" Exit", image=app.exit_icon, compound="left", command=app.on_closing)
     app.exit_btn.grid(row=2, column=3, sticky="ew", pady=2)

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -7,6 +7,7 @@ from tkinter import ttk, filedialog, messagebox
 from config import (
     BRAND_COLORS,
     PDF_TXT_DIR,
+    NEED_REVIEW_DIR,
     CACHE_DIR,
     ASSETS_DIR,
 )
@@ -153,6 +154,14 @@ class KyoQAToolApp(tk.Tk):
 
     def open_result(self) -> None:  # pragma: no cover - GUI behavior
         messagebox.showinfo("Open", "Opening result Excel file.")
+
+    def open_review_folder(self) -> None:  # pragma: no cover - GUI behavior
+        """Open the folder containing PDFs that need review."""
+        from file_utils import open_file
+        review_path = NEED_REVIEW_DIR
+        opened = open_file(review_path)
+        if not opened:
+            messagebox.showinfo("Review Folder", f"Path: {review_path}")
 
     def browse_excel(self) -> None:  # pragma: no cover - GUI behavior
         path = filedialog.askopenfilename(filetypes=[("Excel", "*.xlsx")])

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -29,10 +29,27 @@ def test_ensure_folders_creates_review_subdir(tmp_path: Path, monkeypatch):
     monkeypatch.setattr('config.LOGS_DIR', tmp_path / 'logs')
     monkeypatch.setattr('config.OUTPUT_DIR', tmp_path / 'output')
     monkeypatch.setattr('config.CACHE_DIR', tmp_path / '.cache')
-    review_dir = tmp_path / 'PDF_TXT' / 'needs_review'
+    review_dir = tmp_path / 'NEED_REVIEW' / 'needs_review'
+    monkeypatch.setattr('config.NEED_REVIEW_DIR', review_dir.parent)
+    monkeypatch.setattr('config.OCR_FAILED_DIR', tmp_path / 'OCR_FAILED')
     monkeypatch.setattr('config.PDF_TXT_DIR', review_dir.parent)
 
     ensure_folders()
     assert review_dir.exists()
+
+
+def test_ensure_folders_renames_pdf_txt(tmp_path: Path, monkeypatch):
+    old_dir = tmp_path / 'PDF_TXT'
+    old_dir.mkdir()
+    monkeypatch.setattr('config.NEED_REVIEW_DIR', tmp_path / 'NEED_REVIEW')
+    monkeypatch.setattr('config.OCR_FAILED_DIR', tmp_path / 'OCR_FAILED')
+    monkeypatch.setattr('config.PDF_TXT_DIR', tmp_path / 'NEED_REVIEW')
+    monkeypatch.setattr('config.LOGS_DIR', tmp_path / 'logs')
+    monkeypatch.setattr('config.OUTPUT_DIR', tmp_path / 'output')
+    monkeypatch.setattr('config.CACHE_DIR', tmp_path / '.cache')
+
+    ensure_folders()
+    assert not old_dir.exists()
+    assert (tmp_path / 'NEED_REVIEW').exists()
 
 

--- a/tests/test_kyo_qa_tool_app.py
+++ b/tests/test_kyo_qa_tool_app.py
@@ -39,7 +39,7 @@ if not hasattr(kyo_qa_tool_app.KyoQAToolApp, "_collect_review_pdfs"):
 
 
 def test_collect_review_pdfs(tmp_path, monkeypatch):
-    pdf_txt = tmp_path / "PDF_TXT"
+    pdf_txt = tmp_path / "NEED_REVIEW"
     cache_dir = tmp_path / ".cache"
     pdf_txt.mkdir()
     cache_dir.mkdir()
@@ -52,6 +52,7 @@ def test_collect_review_pdfs(tmp_path, monkeypatch):
         json.dump({"pdf_path": str(pdf)}, f)
 
     monkeypatch.setattr(kyo_qa_tool_app, "PDF_TXT_DIR", pdf_txt, raising=False)
+    monkeypatch.setattr(kyo_qa_tool_app, "NEED_REVIEW_DIR", pdf_txt, raising=False)
     monkeypatch.setattr(kyo_qa_tool_app, "CACHE_DIR", cache_dir, raising=False)
 
     app = kyo_qa_tool_app.KyoQAToolApp.__new__(kyo_qa_tool_app.KyoQAToolApp)


### PR DESCRIPTION
## Summary
- introduce NEED_REVIEW and OCR_FAILED directories
- rename PDF_TXT folder if present and create review subfolder
- move PDFs on OCR or processing errors to the appropriate folder
- add "Open Review Folder" button to the UI
- expose helper to move files with logging
- update tests for new folder logic

## Testing
- `ruff check .` *(fails: 14 errors)*
- `pytest -q` *(fails: 14 failed, 19 passed)*


------
https://chatgpt.com/codex/tasks/task_e_6865f4adb690832e832bc240c63e13b5