### PR TITLE
Add branding constants tests

### DIFF
--- a/branding.py
+++ b/branding.py
@@ -26,3 +26,12 @@ class KyoceraColors:
     STATUS_WARNING = "#ffc107"        # Yellow for warnings
     STATUS_ERROR = "#dc3545"          # Red for errors
     STATUS_INFO_TEXT = "#0dcaf0"      # Cyan for informational link buttons
+
+    # Legacy aliases for backward compatibility
+    BACKGROUND_WIDGET = WIDGET_BG
+    KYOCERA_BLACK = "#000000"
+    TEXT_PRIMARY = TEXT_DARK
+    TEXT_SECONDARY = TEXT_MUTED
+    PRIMARY_BLUE = PRIMARY_ACTION
+    STATUS_INFO = STATUS_INFO_TEXT
+

--- a/tests/test_branding_constants.py
+++ b/tests/test_branding_constants.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from branding import KyoceraColors
+
+
+EXPECTED_COLORS = {
+    "KYOCERA_RED": "#DA291C",
+    "BACKGROUND_MAIN": "#F0F2F5",
+    "WIDGET_BG": "#FFFFFF",
+    "TEXT_DARK": "#212529",
+    "TEXT_MUTED": "#6c757d",
+    "PRIMARY_ACTION": "#0d6efd",
+    "PRIMARY_ACTION_HOVER": "#0b5ed7",
+    "BORDER_COLOR": "#ced4da",
+    "STATUS_SUCCESS": "#198754",
+    "STATUS_WARNING": "#ffc107",
+    "STATUS_ERROR": "#dc3545",
+    "STATUS_INFO_TEXT": "#0dcaf0",
+}
+
+
+def test_branding_constants():
+    for attr, expected in EXPECTED_COLORS.items():
+        assert getattr(KyoceraColors, attr) == expected
+

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -18,6 +18,7 @@ if 'PIL.Image' not in sys.modules:
 processing_stub = types.ModuleType("processing_engine")
 processing_stub.process_folder = lambda *a, **k: None
 processing_stub.process_zip_archive = lambda *a, **k: None
+processing_stub.run_processing_job = lambda *a, **k: None
 sys.modules.setdefault("processing_engine", processing_stub)
 
 # Stub Pillow's Image module


### PR DESCRIPTION
## Summary
- add high-level color aliases for compatibility
- ensure CLI runner stub exposes run_processing_job
- test KyoceraColors values in new unit test

## Testing
- `ruff check branding.py tests/test_cli_runner.py tests/test_branding_constants.py`
- `pytest -q tests/test_branding_constants.py`
- `pytest -q` *(fails: bulletproof_extraction and others missing)*

------
https://chatgpt.com/codex/tasks/task_e_686afa7e6828832e90f1f3e406a91c0f