### PR TITLE
Add extended color palette

### DIFF
--- a/branding.py
+++ b/branding.py
@@ -26,3 +26,22 @@ class KyoceraColors:
     STATUS_WARNING = "#ffc107"        # Yellow for warnings
     STATUS_ERROR = "#dc3545"          # Red for errors
     STATUS_INFO_TEXT = "#0dcaf0"      # Cyan for informational link buttons
+
+    # Aliases and Additional Colors
+    BACKGROUND_WIDGET = WIDGET_BG
+    KYOCERA_BLACK = "#000000"
+    TEXT_PRIMARY = TEXT_DARK
+    TEXT_SECONDARY = TEXT_MUTED
+    PRIMARY_BLUE = PRIMARY_ACTION
+    STATUS_INFO = STATUS_INFO_TEXT
+    DARK_GREY = "#282828"
+    LIGHT_GREY = "#F2F2F2"
+    PURPLE = "#6D2C91"
+    STATUS_ORANGE_LIGHT = "#FAD9C6"
+    STATUS_BLUE_LIGHT = "#CCE5F3"
+    STATUS_GREEN_LIGHT = "#CCEFDA"
+    STATUS_RED_LIGHT = "#F5B7B1"
+
+    # WCAG-compliant high-contrast colors
+    HIGH_CONTRAST_BG = "#000000"
+    HIGH_CONTRAST_TEXT = "#FFFFFF"

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from branding import KyoceraColors
+
+
+def test_branding_aliases():
+    assert KyoceraColors.BACKGROUND_WIDGET == KyoceraColors.WIDGET_BG
+    assert KyoceraColors.TEXT_PRIMARY == KyoceraColors.TEXT_DARK
+    assert KyoceraColors.TEXT_SECONDARY == KyoceraColors.TEXT_MUTED
+    assert KyoceraColors.PRIMARY_BLUE == KyoceraColors.PRIMARY_ACTION
+    assert KyoceraColors.STATUS_INFO == KyoceraColors.STATUS_INFO_TEXT
+
+
+def test_high_contrast_colors():
+    assert KyoceraColors.HIGH_CONTRAST_BG == "#000000"
+    assert KyoceraColors.HIGH_CONTRAST_TEXT == "#FFFFFF"
+


### PR DESCRIPTION
## Summary
- expand KyoceraColors with more aliases and light/contrast options
- test the new constants

## Testing
- `python -m py_compile branding.py tests/test_branding.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686afa7d15d4832e9bcbf2c30838c9ca