### PR TITLE
Add branding constants test and compatibility

### DIFF
--- a/branding.py
+++ b/branding.py
@@ -26,3 +26,11 @@ class KyoceraColors:
     STATUS_WARNING = "#ffc107"        # Yellow for warnings
     STATUS_ERROR = "#dc3545"          # Red for errors
     STATUS_INFO_TEXT = "#0dcaf0"      # Cyan for informational link buttons
+
+    # Backwards compatibility aliases
+    BACKGROUND_WIDGET = WIDGET_BG
+    KYOCERA_BLACK = "#000000"
+    TEXT_PRIMARY = TEXT_DARK
+    TEXT_SECONDARY = TEXT_MUTED
+    PRIMARY_BLUE = PRIMARY_ACTION
+    STATUS_INFO = STATUS_INFO_TEXT

--- a/tests/test_branding_constants.py
+++ b/tests/test_branding_constants.py
@@ -1,0 +1,8 @@
+from branding import KyoceraColors
+
+
+def test_color_constants():
+    assert KyoceraColors.KYOCERA_RED == "#DA291C"
+    assert KyoceraColors.BACKGROUND_MAIN == "#F0F2F5"
+    assert KyoceraColors.WIDGET_BG == "#FFFFFF"
+    assert KyoceraColors.STATUS_SUCCESS == "#198754"

--- a/tests/test_kyo_qa_tool_app.py
+++ b/tests/test_kyo_qa_tool_app.py
@@ -16,7 +16,7 @@ pytesseract_mod.image_to_string = lambda *a, **k: ""
 sys.modules.setdefault("pytesseract", pytesseract_mod)
 
 # Ensure any stubbed processing_engine from other tests is cleared
-sys.modules.pop("processing_engine", None)
+monkeypatch.delitem(sys.modules, "processing_engine", raising=False)
 
 import kyo_qa_tool_app  # noqa: E402
 

--- a/tests/test_kyo_qa_tool_app.py
+++ b/tests/test_kyo_qa_tool_app.py
@@ -15,6 +15,9 @@ pytesseract_mod = types.ModuleType("pytesseract")
 pytesseract_mod.image_to_string = lambda *a, **k: ""
 sys.modules.setdefault("pytesseract", pytesseract_mod)
 
+# Ensure any stubbed processing_engine from other tests is cleared
+sys.modules.pop("processing_engine", None)
+
 import kyo_qa_tool_app  # noqa: E402
 
 if not hasattr(kyo_qa_tool_app, "KyoQAToolApp"):


### PR DESCRIPTION
## Summary
- add backwards compatibility color aliases in `branding.py`
- clear stubbed `processing_engine` when testing the app
- check core branding colors with a new unit test

## Testing
- `ruff check branding.py tests/test_branding_constants.py tests/test_kyo_qa_tool_app.py`
- `pytest -q tests/test_branding_constants.py`
- `pytest -q tests/test_kyo_qa_tool_app.py::test_collect_review_pdfs`


------
https://chatgpt.com/codex/tasks/task_e_686afa802460832e957cb9d1a4a1ec98