### PR TITLE
Add pause/resume with spinner

### DIFF
--- a/gui_components.py
+++ b/gui_components.py
@@ -103,10 +103,13 @@ def create_live_status_section(parent, app):
     activity_frame = ttk.Frame(container, style='Card.TFrame')
     activity_frame.grid(row=0, column=0, sticky='ew', pady=(0, 15))
     activity_frame.columnconfigure(1, weight=1)
+    activity_frame.columnconfigure(2, weight=0)
     
     ttk.Label(activity_frame, text="Activity:", font=('Segoe UI', 11, 'bold'), style='Card.TLabel').grid(row=0, column=0, padx=10, pady=5)
     app.status_current_file = tk.StringVar(value="Waiting to start...")
     ttk.Label(activity_frame, textvariable=app.status_current_file, style='Card.TLabel', foreground=KyoceraColors.TEXT_MUTED).grid(row=0, column=1, sticky='ew')
+    app.spinner_label = ttk.Label(activity_frame, text="", width=2, style='Card.TLabel')
+    app.spinner_label.grid(row=0, column=2, padx=(5,0), sticky='w')
     
     app.progress_bar = ttk.Progressbar(activity_frame, variable=app.progress_value, mode='determinate')
     app.progress_bar.grid(row=1, column=0, columnspan=2, sticky='ew', padx=10, pady=(5,10))

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -3,17 +3,15 @@
 # Last modified: 2025-07-06
 
 import tkinter as tk
-from tkinter import filedialog, messagebox, ttk
+from tkinter import filedialog, messagebox
 from pathlib import Path
 import threading
 import queue
 import time
 import sys
-import webbrowser
 
-from config import ASSETS_DIR
 from processing_engine import run_processing_job
-from file_utils import open_file, ensure_folders, cleanup_directory, extract_zip_to_temp
+from file_utils import ensure_folders, cleanup_directory, extract_zip_to_temp
 from kyo_review_tool import ReviewWindow
 from version import VERSION
 import logging_utils
@@ -42,6 +40,8 @@ class KyoQAToolApp(tk.Tk):
         self.reviewable_files = []
         self.response_queue = queue.Queue()
         self.cancel_event = threading.Event()
+        self.pause_event = threading.Event()
+        self.spinner_running = False
         
         self.selected_folder = tk.StringVar()
         self.selected_excel = tk.StringVar()
@@ -88,15 +88,22 @@ class KyoQAToolApp(tk.Tk):
 
     def start_processing(self):
         """Validates inputs and starts the processing job in a thread."""
-        if self.is_processing: return
+        if self.is_processing:
+            return
         
         input_path = self.selected_folder.get() or self.selected_files_list
         if not input_path:
-            messagebox.showwarning("Input Missing", "Please select a PDF source (folder, files, or ZIP).")
+            messagebox.showwarning(
+                "Input Missing",
+                "Please select a PDF source (folder, files, or ZIP).",
+            )
             return
         excel_path = self.selected_excel.get()
         if not excel_path:
-            messagebox.showwarning("Input Missing", "Please select an Excel template file.")
+            messagebox.showwarning(
+                "Input Missing",
+                "Please select an Excel template file.",
+            )
             return
             
         job = {"excel_path": excel_path, "input_path": input_path}
@@ -104,19 +111,23 @@ class KyoQAToolApp(tk.Tk):
         self.update_ui_for_start()
         self.log_message("Starting processing job...", "info")
         
-        threading.Thread(target=run_processing_job, 
-                         args=(job, self.response_queue, self.cancel_event), 
-                         daemon=True).start()
+        threading.Thread(
+            target=run_processing_job,
+            args=(job, self.response_queue, self.cancel_event, self.pause_event),
+            daemon=True,
+        ).start()
 
     def browse_zip(self):
         """Handles browsing for and extracting a ZIP archive."""
         path = filedialog.askopenfilename(title="Select ZIP Archive", filetypes=[("ZIP Archives", "*.zip")])
-        if not path: return
+        if not path:
+            return
 
         zip_path = Path(path)
         self.log_message(f"Extracting PDFs from: {zip_path.name}", "info")
         
-        if self.temp_dir_to_clean: cleanup_directory(self.temp_dir_to_clean)
+        if self.temp_dir_to_clean:
+            cleanup_directory(self.temp_dir_to_clean)
         
         temp_dir = extract_zip_to_temp(zip_path)
         if not temp_dir:
@@ -137,8 +148,11 @@ class KyoQAToolApp(tk.Tk):
         self.log_message(f"Ready to process {len(pdf_files)} files from {zip_path.name}.", "success")
 
     def browse_excel(self):
-        path = filedialog.askopenfilename(title="Select Excel Template", filetypes=[("Excel Files", "*.xlsx *.xlsm")])
-        if path: self.selected_excel.set(path)
+        path = filedialog.askopenfilename(
+            title="Select Excel Template", filetypes=[("Excel Files", "*.xlsx *.xlsm")]
+        )
+        if path:
+            self.selected_excel.set(path)
 
     def browse_folder(self):
         path = filedialog.askdirectory(title="Select Folder with PDFs")
@@ -158,7 +172,8 @@ class KyoQAToolApp(tk.Tk):
             return
         
         self.cancel_event.set()
-        if self.temp_dir_to_clean: cleanup_directory(self.temp_dir_to_clean)
+        if self.temp_dir_to_clean:
+            cleanup_directory(self.temp_dir_to_clean)
         
         self.destroy()
 
@@ -173,6 +188,9 @@ class KyoQAToolApp(tk.Tk):
         self.reviewable_files.clear()
         self.review_tree.delete(*self.review_tree.get_children())
         self.process_btn.config(state=tk.DISABLED)
+
+        self.spinner_running = True
+        threading.Thread(target=self._spinner_worker, daemon=True).start()
         
         # Reset counters
         for var in [self.count_processed, self.count_pass, self.count_fail, self.count_review]:
@@ -185,10 +203,25 @@ class KyoQAToolApp(tk.Tk):
         self.is_processing = False
         self.process_btn.config(state=tk.NORMAL)
         self.status_current_file.set(f"Job {status}.")
+        self.spinner_running = False
+        if hasattr(self, "spinner_label"):
+            self.spinner_label.config(text="")
         
         if self.temp_dir_to_clean:
             cleanup_directory(self.temp_dir_to_clean)
             self.temp_dir_to_clean = None
+
+    def _spinner_worker(self):
+        frames = "|/-\\"
+        idx = 0
+        while self.spinner_running and not self.cancel_event.is_set():
+            if self.pause_event.is_set():
+                time.sleep(0.2)
+                continue
+            if hasattr(self, "spinner_label"):
+                self.spinner_label.config(text=frames[idx % len(frames)])
+            idx += 1
+            time.sleep(0.1)
 
     def open_review_for_selected_file(self):
         """Opens the pattern review tool for the selected file."""
@@ -246,6 +279,16 @@ class KyoQAToolApp(tk.Tk):
         if messagebox.askyesno("Confirm Stop", "Are you sure you want to stop the current job?"):
             self.cancel_event.set()
             self.log_message("Stop request sent to processing thread.", "warning")
+
+    def pause_processing(self):
+        self.pause_event.set()
+        self.status_current_file.set("Processing paused")
+        self.log_message("Processing paused", "info")
+
+    def resume_processing(self):
+        self.pause_event.clear()
+        self.status_current_file.set("Resuming...")
+        self.log_message("Processing resumed", "info")
 
 def main():
     try:

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -2,12 +2,10 @@
 import shutil
 import time
 import json
-import os
 import logging
 from pathlib import Path
 from datetime import datetime
 import traceback
-import sys
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -16,7 +14,7 @@ logger = logging.getLogger("processing_engine")
 # Try to import required modules, with fallbacks where possible
 try:
     import openpyxl
-    from openpyxl.styles import PatternFill, Alignment
+    from openpyxl.styles import PatternFill
     from openpyxl.utils import get_column_letter
     OPENPYXL_AVAILABLE = True
 except ImportError:
@@ -234,7 +232,7 @@ def process_single_pdf(pdf_path, progress_queue, ignore_cache=False):
         try:
             with open(cache_path, 'w', encoding='utf-8') as f:
                 json.dump(result, f)
-        except:
+        except Exception:
             pass
             
         return result
@@ -326,8 +324,6 @@ def run_processing_job(job_info, progress_queue, cancel_event, pause_event):
                 progress_queue.put({"type": "status", "msg": "Paused", "led": "Paused"})
                 while pause_event.is_set() and not cancel_event.is_set():
                     time.sleep(0.5)
-                    
-                # Check for cancellation again after pause
                 if cancel_event.is_set():
                     progress_queue.put({"type": "log", "tag": "warning", "msg": "Processing cancelled"})
                     progress_queue.put({"type": "finish", "status": "Cancelled"})
@@ -468,7 +464,7 @@ def run_processing_job(job_info, progress_queue, cancel_event, pause_event):
                             cell_len = len(str(cell.value))
                             if cell_len > max_len:
                                 max_len = cell_len
-                        except:
+                        except Exception:
                             pass
                 
                 adjusted_width = min(max_len + 2, 60)  # Cap width at 60 characters

--- a/tests/test_kyo_qa_tool_app.py
+++ b/tests/test_kyo_qa_tool_app.py
@@ -2,6 +2,7 @@ import sys
 import json
 from pathlib import Path
 import types
+import threading
 from tests.openpyxl_stub import ensure_openpyxl_stub
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -14,9 +15,6 @@ sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 pytesseract_mod = types.ModuleType("pytesseract")
 pytesseract_mod.image_to_string = lambda *a, **k: ""
 sys.modules.setdefault("pytesseract", pytesseract_mod)
-
-# Ensure any stubbed processing_engine from other tests is cleared
-monkeypatch.delitem(sys.modules, "processing_engine", raising=False)
 
 import kyo_qa_tool_app  # noqa: E402
 
@@ -63,4 +61,28 @@ def test_collect_review_pdfs(tmp_path, monkeypatch):
 
     result = app._collect_review_pdfs()
     assert result == [str(pdf)]
+
+
+class DummyVar:
+    def __init__(self):
+        self.value = ""
+
+    def set(self, val):
+        self.value = val
+
+
+def test_pause_resume_events(monkeypatch):
+    app = kyo_qa_tool_app.KyoQAToolApp.__new__(kyo_qa_tool_app.KyoQAToolApp)
+    app.pause_event = threading.Event()
+    app.cancel_event = threading.Event()
+    app.status_current_file = DummyVar()
+    app.log_message = lambda *a, **k: None
+
+    app.pause_processing()
+    assert app.pause_event.is_set()
+    assert app.status_current_file.value == "Processing paused"
+
+    app.resume_processing()
+    assert not app.pause_event.is_set()
+    assert app.status_current_file.value == "Resuming..."
 


### PR DESCRIPTION
## Summary
- support pausing jobs via `pause_event`
- show a simple spinner while processing
- expose `pause_processing` and `resume_processing` helpers
- display spinner label in live status section
- test pause/resume events

## Testing
- `ruff check kyo_qa_tool_app.py gui_components.py processing_engine.py tests/test_kyo_qa_tool_app.py`
- `pytest tests/test_kyo_qa_tool_app.py::test_pause_resume_events -q`
- `pytest -q` *(fails: AttributeError in multiple modules)*

------
https://chatgpt.com/codex/tasks/task_e_686afd6ec12c832e81a1fc21aa336214