### PR TITLE
Add pre-commit config and revert verification script

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+  - repo: local
+    hooks:
+      - id: ensure-clean-working-tree
+        name: ensure-clean-working-tree
+        entry: bash -c 'if [ -n "$(git status --porcelain)" ]; then echo "Working tree not clean." >&2; exit 1; fi'
+        language: system
+        pass_filenames: false

--- a/tests/test_verify_revert_script.py
+++ b/tests/test_verify_revert_script.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+def test_verify_revert_script_exists():
+    script = Path('verify_revert.sh')
+    assert script.exists(), 'verify_revert.sh should exist'
+    content = script.read_text()
+    assert 'git status --porcelain' in content
+    assert 'pytest --maxfail=1 --disable-warnings -q' in content

--- a/verify_revert.sh
+++ b/verify_revert.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree not clean. Aborting revert test." >&2
+  exit 1
+fi
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+git checkout HEAD~1
+pytest --maxfail=1 --disable-warnings -q
+git checkout $current_branch
+echo "Reversion test passed."


### PR DESCRIPTION
## Summary
- introduce `pre-commit-config.yaml` with standard hooks and a custom check to abort if the working tree isn't clean
- add `verify_revert.sh` helper for testing a one-commit rollback
- ensure new script is covered by `test_verify_revert_script.py`

## Testing
- `python -m py_compile tests/test_verify_revert_script.py`
- `pytest tests/test_verify_revert_script.py -q`
- `flake8 tests/test_verify_revert_script.py` *(fails: command not found)*
- `pytest -k verify_revert -q` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b08962ce8832e9df2b226f495796a