### PR TITLE
Add Data Harvesting tab

### DIFF
--- a/gui_components.py
+++ b/gui_components.py
@@ -72,6 +72,18 @@ def setup_high_contrast_styles(app):
         bordercolor=[("!active", KyoceraColors.BACKGROUND_MAIN)],
     )
     style.configure(
+        "Exit.TButton",
+        background=KyoceraColors.HIGH_CONTRAST_BG,
+        foreground=KyoceraColors.HIGH_CONTRAST_TEXT,
+        font=("Segoe UI", 10, "bold"),
+        padding=(5, 3),
+    )
+    style.map(
+        "Exit.TButton",
+        background=[("active", KyoceraColors.HIGH_CONTRAST_BG)],
+        foreground=[("active", KyoceraColors.HIGH_CONTRAST_TEXT)],
+    )
+    style.configure(
         "Treeview",
         rowheight=28,
         fieldbackground=KyoceraColors.WIDGET_BG,
@@ -310,8 +322,50 @@ def create_footer(parent, app):
         footer_frame,
         text="Exit Application",
         command=app.on_closing,
-        style="Footer.TButton",
+        style="Exit.TButton",
     ).pack(side="right")
+
+
+def create_harvest_tab(parent, app):
+    harvest_frame = ttk.Frame(parent, padding=15)
+    harvest_frame.pack(fill="both", expand=True)
+
+    select_frame = ttk.Frame(harvest_frame)
+    select_frame.pack(fill="x")
+    app.harvest_file = tk.StringVar()
+    ttk.Entry(
+        select_frame,
+        textvariable=app.harvest_file,
+        font=("Segoe UI", 10),
+    ).pack(side="left", fill="x", expand=True, padx=5)
+    ttk.Button(select_frame, text="Browse...", command=app.browse_harvest_file).pack(
+        side="left", padx=5
+    )
+
+    btn_frame = ttk.Frame(harvest_frame)
+    btn_frame.pack(fill="x", pady=10)
+    app.harvest_run_btn = ttk.Button(
+        btn_frame, text="Harvest Data", command=app.harvest_single_file
+    )
+    app.harvest_run_btn.pack(side="left")
+    app.harvest_export_btn = ttk.Button(
+        btn_frame,
+        text="Export to XLSX",
+        command=app.export_harvest_results,
+        state=tk.DISABLED,
+    )
+    app.harvest_export_btn.pack(side="left", padx=5)
+
+    app.harvest_text = tk.Text(
+        harvest_frame,
+        wrap=tk.WORD,
+        state=tk.DISABLED,
+        bg=KyoceraColors.HIGH_CONTRAST_BG,
+        fg=KyoceraColors.HIGH_CONTRAST_TEXT,
+    )
+    app.harvest_text.pack(fill="both", expand=True)
+
+    return harvest_frame
 
 def create_review_tab(parent, app):
     review_frame = ttk.Frame(parent, padding=15)

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -323,6 +323,7 @@ class KyoQAToolApp(tk.Tk):
         except Exception as e:
             messagebox.showerror("Export Error", str(e))
             self.status_current_file.set(f"Export failed: {e}")
+            self.harvest_export_btn.config(state=tk.DISABLED)
 
     def pause_processing(self):
         self.pause_event.set()

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -14,6 +14,9 @@ import os
 import json
 
 from processing_engine import process_job
+from ocr_utils import extract_text_from_pdf
+from data_harvesters import harvest_all_data
+from utils import ExcelGenerator
 from file_utils import (
     ensure_folders,
     cleanup_directory,
@@ -32,6 +35,7 @@ from gui_components import (
     create_live_status_section,
     create_footer,
     create_review_tab,
+    create_harvest_tab,
 )
 from config import CACHE_DIR
 
@@ -94,8 +98,10 @@ class KyoQAToolApp(tk.Tk):
 
         process_tab = ttk.Frame(self.notebook)
         review_tab = ttk.Frame(self.notebook)
+        harvest_tab = ttk.Frame(self.notebook)
         self.notebook.add(process_tab, text="Process")
         self.notebook.add(review_tab, text="Review")
+        self.notebook.add(harvest_tab, text="Harvest")
 
         create_main_header(process_tab, VERSION)
         create_io_section(process_tab, self)
@@ -103,6 +109,7 @@ class KyoQAToolApp(tk.Tk):
         create_live_status_section(process_tab, self)
 
         create_review_tab(review_tab, self)
+        create_harvest_tab(harvest_tab, self)
 
         create_footer(self, self)
 
@@ -195,6 +202,11 @@ class KyoQAToolApp(tk.Tk):
         if path:
             self.selected_excel.set(path)
 
+    def browse_harvest_file(self):
+        path = filedialog.askopenfilename(title="Select PDF File", filetypes=[("PDF Files", "*.pdf")])
+        if path:
+            self.harvest_file.set(path)
+
     def on_closing(self):
         if self.is_processing and not messagebox.askyesno(
             "Exit Confirmation", "A job is running. Are you sure you want to exit?"
@@ -265,6 +277,61 @@ class KyoQAToolApp(tk.Tk):
             idx += 1
             time.sleep(0.1)
 
+    def harvest_single_file(self):
+        path_str = self.harvest_file.get()
+        if not path_str:
+            messagebox.showwarning("Input Missing", "Please select a PDF file to harvest.")
+            return
+        pdf = Path(path_str)
+        if not pdf.exists():
+            messagebox.showerror("File Not Found", f"{pdf} does not exist")
+            return
+        self.spinner_running = True
+        threading.Thread(target=self._spinner_worker, daemon=True).start()
+        threading.Thread(target=self._harvest_worker, args=(pdf,), daemon=True).start()
+
+    def _harvest_worker(self, pdf):
+        try:
+            self.status_current_file.set(f"Harvesting {pdf.name}...")
+            text = extract_text_from_pdf(str(pdf.resolve()))
+            data = harvest_all_data(text, pdf.name)
+            self.harvest_results = [{"filename": pdf.name, **data}]
+            result_text = f"Models: {data.get('models')}\nAuthor: {data.get('author')}"
+            self.harvest_text.config(state=tk.NORMAL)
+            self.harvest_text.delete("1.0", tk.END)
+            self.harvest_text.insert("1.0", result_text)
+            self.harvest_text.config(state=tk.DISABLED)
+            self.harvest_export_btn.config(state=tk.NORMAL)
+            self.status_current_file.set("Harvest complete")
+        except Exception as e:
+            self.status_current_file.set(f"Harvest failed: {e}")
+            messagebox.showerror("Harvest Error", str(e))
+            self.harvest_results = []
+            self.harvest_export_btn.config(state=tk.DISABLED)
+        finally:
+            self.spinner_running = False
+
+    def export_harvest_results(self):
+        if not getattr(self, "harvest_results", None):
+            messagebox.showinfo("No Data", "Nothing to export.")
+            return
+        try:
+            pdf = Path(self.harvest_file.get())
+            out_path = pdf.with_name(pdf.stem + "_harvest.xlsx")
+            ExcelGenerator(str(out_path)).create_report(self.harvest_results)
+            self.status_current_file.set(f"Export complete: {out_path}")
+        except Exception as e:
+            messagebox.showerror("Export Error", str(e))
+            self.status_current_file.set(f"Export failed: {e}")
+
+    def pause_processing(self):
+        self.pause_event.set()
+        self.status_current_file.set("Processing paused")
+
+    def resume_processing(self):
+        self.pause_event.clear()
+        self.status_current_file.set("Resuming...")
+
     def open_review_for_selected_file(self):
         selection = self.review_tree.selection()
         if not selection:
@@ -283,6 +350,7 @@ class KyoQAToolApp(tk.Tk):
         )
         if hasattr(self, "review_table"):
             self.review_table.delete(*self.review_table.get_children())
+        loaded = 0
         for json_file in CACHE_DIR.glob("*.json"):
             try:
                 with open(json_file, "r", encoding="utf-8") as f:
@@ -297,10 +365,13 @@ class KyoQAToolApp(tk.Tk):
                 iid = self.review_table.insert(
                     "", "end", values=(data.get("filename"), status)
                 )
+                loaded += 1
                 if status == "Needs Review":
                     self.review_table.item(iid, tags=("review",))
                 elif status == "Fail":
                     self.review_table.item(iid, tags=("fail",))
+        if loaded == 0:
+            messagebox.showinfo("Review", "No items found for the selected filter.")
 
     def process_response_queue(self):
         try:

--- a/tests/test_harvest_tab.py
+++ b/tests/test_harvest_tab.py
@@ -1,0 +1,39 @@
+import sys
+import types
+from pathlib import Path
+from tests.openpyxl_stub import ensure_openpyxl_stub
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+ensure_openpyxl_stub()
+sys.modules.setdefault("fitz", types.ModuleType("fitz"))
+sys.modules.pop("processing_engine", None)
+
+import kyo_qa_tool_app  # noqa: E402
+
+
+def test_export_harvest_results(monkeypatch, tmp_path):
+    app = kyo_qa_tool_app.KyoQAToolApp.__new__(kyo_qa_tool_app.KyoQAToolApp)
+    app.harvest_results = [{"filename": "file.pdf", "models": "A", "author": "X"}]
+    pdf_path = tmp_path / "file.pdf"
+    pdf_path.write_text("dummy")
+    app.harvest_file = types.SimpleNamespace(get=lambda: str(pdf_path))
+    called = {}
+
+    class DummyExcel:
+        def __init__(self, path):
+            called["path"] = path
+        def create_report(self, data):
+            called["data"] = data
+
+    monkeypatch.setattr(kyo_qa_tool_app, "ExcelGenerator", DummyExcel)
+    monkeypatch.setattr(kyo_qa_tool_app.messagebox, "showinfo", lambda *a, **k: None)
+    monkeypatch.setattr(kyo_qa_tool_app.messagebox, "showerror", lambda *a, **k: None)
+    app.status_current_file = types.SimpleNamespace(set=lambda x: called.setdefault("status", x))
+    app.harvest_export_btn = types.SimpleNamespace(config=lambda **kw: None)
+
+    kyo_qa_tool_app.KyoQAToolApp.export_harvest_results(app)
+
+    assert called["data"] == app.harvest_results
+    assert pdf_path.with_name("file_harvest.xlsx").as_posix() == called["path"]
+    assert "Export complete" in called["status"]


### PR DESCRIPTION
## Summary
- integrate high-contrast Exit button style
- add Data Harvesting tab with PDF browse, harvest and export
- wire export to ExcelGenerator
- expose pause and resume helpers
- test export path on Data Harvesting tab

## Testing
- `black . --check` *(fails: would reformat many files)*
- `flake8` *(fails: command not found)*
- `pytest tests/test_harvest_tab.py -q`
- `pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686b412d249c832e8c6a2618ce9842fa