### PR TITLE
Fix duplicate import in QA tool

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -33,7 +33,6 @@ from gui_components import (
     create_footer,
     create_review_tab,
 )
-from config import CACHE_DIR
 
 logger = logging_utils.setup_logger("app")
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,9 @@
+import re
+from pathlib import Path
+
+
+def test_single_cache_dir_import():
+    content = Path("kyo_qa_tool_app.py").read_text()
+    assert (
+        len(re.findall(r"^from config import CACHE_DIR$", content, re.MULTILINE)) == 1
+    )


### PR DESCRIPTION
## Summary
- remove redundant `CACHE_DIR` import from `kyo_qa_tool_app.py`
- add regression test to ensure the import appears once

## Testing
- `black kyo_qa_tool_app.py tests/test_imports.py`
- `flake8` *(fails: command not found)*
- `pytest tests/test_imports.py -q`
- `pytest -q` *(fails: ImportError processing_engine)*

------
https://chatgpt.com/codex/tasks/task_e_686b43fb519c832e91fabc0948224d38