### PR TITLE
Add Exit button style

### DIFF
--- a/gui_components.py
+++ b/gui_components.py
@@ -72,6 +72,11 @@ def setup_high_contrast_styles(app):
         bordercolor=[("!active", KyoceraColors.BACKGROUND_MAIN)],
     )
     style.configure(
+        "Exit.TButton",
+        background=KyoceraColors.HIGH_CONTRAST_BG,
+        foreground=KyoceraColors.HIGH_CONTRAST_TEXT,
+    )
+    style.configure(
         "Treeview",
         rowheight=28,
         fieldbackground=KyoceraColors.WIDGET_BG,
@@ -310,8 +315,9 @@ def create_footer(parent, app):
         footer_frame,
         text="Exit Application",
         command=app.on_closing,
-        style="Footer.TButton",
+        style="Exit.TButton",
     ).pack(side="right")
+
 
 def create_review_tab(parent, app):
     review_frame = ttk.Frame(parent, padding=15)

--- a/tests/test_exit_button_style.py
+++ b/tests/test_exit_button_style.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import types
+import tkinter as tk
+from tkinter import ttk
+from pathlib import Path
+import pytest
+
+if not os.environ.get("DISPLAY"):
+    pytest.skip("Tk display not available", allow_module_level=True)
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import gui_components
+from branding import KyoceraColors
+
+
+def test_setup_high_contrast_creates_exit_style():
+    root = tk.Tk()
+    root.withdraw()
+    gui_components.setup_high_contrast_styles(root)
+    style = ttk.Style(root)
+    bg = style.lookup("Exit.TButton", "background")
+    fg = style.lookup("Exit.TButton", "foreground")
+    root.destroy()
+    assert bg == KyoceraColors.HIGH_CONTRAST_BG
+    assert fg == KyoceraColors.HIGH_CONTRAST_TEXT
+
+
+def test_create_footer_uses_exit_style(monkeypatch):
+    root = tk.Tk()
+    root.withdraw()
+    dummy_app = types.SimpleNamespace(
+        fullscreen_status_var=tk.StringVar(),
+        on_closing=lambda: None,
+    )
+    created = {}
+    orig_button = ttk.Button
+
+    def spy_button(master, **kw):
+        created["style"] = kw.get("style")
+        return orig_button(master, **kw)
+
+    monkeypatch.setattr(ttk, "Button", spy_button)
+    gui_components.create_footer(root, dummy_app)
+    root.destroy()
+    assert created.get("style") == "Exit.TButton"


### PR DESCRIPTION
## Summary
- style buttons for high contrast exit control
- style the exit button in the footer
- add unit test for Exit button style

## Testing
- `black --check gui_components.py tests/test_exit_button_style.py`
- `mypy gui_components.py`
- `pytest tests/test_exit_button_style.py -q`
- `pytest -q` *(fails: ImportError in test_kyo_qa_tool_app.py)*

------
https://chatgpt.com/codex/tasks/task_e_686b4404c7b4832e82e7fb0611e39865