### PR TITLE
Add manual export to XLSX

### DIFF
--- a/gui_components.py
+++ b/gui_components.py
@@ -178,6 +178,14 @@ def create_controls_section(parent, app):
     )
     app.process_btn.grid(row=0, column=0, sticky="ew", ipady=8, pady=(0, 10))
 
+    # Button to manually export cached results to Excel
+    app.export_btn = ttk.Button(
+        controls_frame,
+        text="Export to XLSX",
+        command=app.manual_export,
+    )
+    app.export_btn.grid(row=1, column=0, sticky="ew")
+
 
 def create_live_status_section(parent, app):
     container = ttk.Frame(parent, padding=10)

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -13,7 +13,7 @@ import sys
 import os
 import json
 
-from processing_engine import process_job
+from processing_engine import process_job, export_to_excel
 from file_utils import (
     ensure_folders,
     cleanup_directory,
@@ -301,6 +301,35 @@ class KyoQAToolApp(tk.Tk):
                     self.review_table.item(iid, tags=("review",))
                 elif status == "Fail":
                     self.review_table.item(iid, tags=("fail",))
+
+    def manual_export(self):
+        """Export cached results to the selected Excel template."""
+        excel_path = self.selected_excel.get() if hasattr(self, "selected_excel") else ""
+        if not excel_path:
+            messagebox.showwarning("Input Missing", "Please select an Excel template file.")
+            return
+
+        results = []
+        for json_file in CACHE_DIR.glob("*.json"):
+            try:
+                with open(json_file, "r", encoding="utf-8") as f:
+                    results.append(json.load(f))
+            except Exception as e:
+                logger.error(f"Failed loading {json_file}: {e}")
+
+        if not results:
+            messagebox.showinfo("No Data", "No results available for export.")
+            return
+
+        try:
+            output = export_to_excel(results, Path(excel_path), self.response_queue)
+            if output:
+                self.status_current_file.set(f"Export complete: {output}")
+            else:
+                messagebox.showerror("Export Error", "Failed to export to Excel.")
+        except Exception as e:
+            logger.error("Manual export failed", exc_info=True)
+            messagebox.showerror("Export Error", str(e))
 
     def process_response_queue(self):
         try:

--- a/tests/test_kyo_qa_tool_app.py
+++ b/tests/test_kyo_qa_tool_app.py
@@ -73,6 +73,9 @@ class DummyVar:
     def set(self, val):
         self.value = val
 
+    def get(self):
+        return self.value
+
 
 def test_pause_resume_events(monkeypatch):
     app = kyo_qa_tool_app.KyoQAToolApp.__new__(kyo_qa_tool_app.KyoQAToolApp)
@@ -108,3 +111,36 @@ def test_process_response_queue_updates_status(monkeypatch):
     app.process_response_queue()
 
     assert app.status_current_file.value == "Harvesting record 5 of 20..."
+
+
+def test_manual_export_reads_cache_and_updates_status(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    result_data = {"filename": "doc.pdf", "models": "m1", "author": "a", "status": "Pass"}
+    with open(cache_dir / "doc.json", "w", encoding="utf-8") as f:
+        json.dump(result_data, f)
+
+    monkeypatch.setattr(kyo_qa_tool_app, "CACHE_DIR", cache_dir, raising=False)
+
+    exported = {}
+
+    def fake_export(results, excel, queue):
+        exported["results"] = results
+        return Path("out.xlsx")
+
+    monkeypatch.setattr(kyo_qa_tool_app, "export_to_excel", fake_export)
+
+    app = kyo_qa_tool_app.KyoQAToolApp.__new__(kyo_qa_tool_app.KyoQAToolApp)
+    app.selected_excel = DummyVar()
+    app.selected_excel.set("template.xlsx")
+    app.status_current_file = DummyVar()
+    app.response_queue = queue.Queue()
+
+    monkeypatch.setattr(kyo_qa_tool_app.messagebox, "showwarning", lambda *a, **k: None)
+    monkeypatch.setattr(kyo_qa_tool_app.messagebox, "showinfo", lambda *a, **k: None)
+    monkeypatch.setattr(kyo_qa_tool_app.messagebox, "showerror", lambda *a, **k: None)
+
+    app.manual_export()
+
+    assert exported["results"][0]["filename"] == "doc.pdf"
+    assert app.status_current_file.value.startswith("Export complete")


### PR DESCRIPTION
## Summary
- add `Export to XLSX` button in controls section
- implement `manual_export` in `KyoQAToolApp`
- test export workflow via cached results

## Testing
- `python -m py_compile gui_components.py kyo_qa_tool_app.py tests/test_kyo_qa_tool_app.py`
- `pytest -q tests/test_kyo_qa_tool_app.py::test_manual_export_reads_cache_and_updates_status`

------
https://chatgpt.com/codex/tasks/task_e_686b43f07fd0832e9844de317f27bf44