### PR TITLE
Add empty state label for review tab

### DIFF
--- a/gui_components.py
+++ b/gui_components.py
@@ -113,6 +113,12 @@ def setup_high_contrast_styles(app):
     style.configure(
         "FailRow", background=KyoceraColors.STATUS_ERROR, foreground="white"
     )
+    style.configure(
+        "EmptyState.TLabel",
+        foreground=KyoceraColors.HIGH_CONTRAST_TEXT,
+        background=KyoceraColors.HIGH_CONTRAST_BG,
+        font=("Segoe UI", 12, "bold"),
+    )
 
 
 def create_main_header(parent, version):
@@ -313,6 +319,7 @@ def create_footer(parent, app):
         style="Footer.TButton",
     ).pack(side="right")
 
+
 def create_review_tab(parent, app):
     review_frame = ttk.Frame(parent, padding=15)
     review_frame.pack(fill="both", expand=True)
@@ -344,5 +351,13 @@ def create_review_tab(parent, app):
     app.review_table.pack(fill="both", expand=True)
     app.review_table.tag_configure("review", style="ReviewRow")
     app.review_table.tag_configure("fail", style="FailRow")
+
+    app.empty_label = ttk.Label(
+        review_frame,
+        text="No items to display",
+        style="EmptyState.TLabel",
+    )
+    app.empty_label.pack(pady=10)
+    app.empty_label.pack_forget()
 
     return review_frame

--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -283,6 +283,7 @@ class KyoQAToolApp(tk.Tk):
         )
         if hasattr(self, "review_table"):
             self.review_table.delete(*self.review_table.get_children())
+        inserted = 0
         for json_file in CACHE_DIR.glob("*.json"):
             try:
                 with open(json_file, "r", encoding="utf-8") as f:
@@ -297,10 +298,16 @@ class KyoQAToolApp(tk.Tk):
                 iid = self.review_table.insert(
                     "", "end", values=(data.get("filename"), status)
                 )
+                inserted += 1
                 if status == "Needs Review":
                     self.review_table.item(iid, tags=("review",))
                 elif status == "Fail":
                     self.review_table.item(iid, tags=("fail",))
+        if "empty_label" in self.__dict__:
+            if inserted == 0:
+                self.empty_label.pack(pady=10)
+            else:
+                self.empty_label.pack_forget()
 
     def process_response_queue(self):
         try:

--- a/tests/test_review_tab.py
+++ b/tests/test_review_tab.py
@@ -38,6 +38,17 @@ class DummyTree:
         pass
 
 
+class DummyLabel:
+    def __init__(self):
+        self.visible = False
+
+    def pack(self, *args, **kwargs):
+        self.visible = True
+
+    def pack_forget(self):
+        self.visible = False
+
+
 def test_load_review_data(monkeypatch, tmp_path):
     cache_dir = tmp_path
     data1 = {"filename": "file1.pdf", "status": "Pass"}
@@ -57,3 +68,21 @@ def test_load_review_data(monkeypatch, tmp_path):
     assert len(tree.rows) == 2
     filenames = {row["values"][0] for row in tree.rows}
     assert {"file1.pdf", "file2.pdf"} == filenames
+
+
+def test_load_review_data_empty(monkeypatch, tmp_path):
+    cache_dir = tmp_path
+
+    monkeypatch.setattr(kyo_qa_tool_app, "CACHE_DIR", cache_dir, raising=False)
+
+    app = kyo_qa_tool_app.KyoQAToolApp.__new__(kyo_qa_tool_app.KyoQAToolApp)
+    app.review_filter = types.SimpleNamespace(get=lambda: "All")
+    tree = DummyTree()
+    label = DummyLabel()
+    app.review_table = tree
+    app.empty_label = label
+
+    kyo_qa_tool_app.KyoQAToolApp.load_review_data(app)
+
+    assert len(tree.rows) == 0
+    assert label.visible


### PR DESCRIPTION
## Summary
- show a high contrast label in the review tab when there are no rows to display
- toggle the label once rows appear
- add new style `EmptyState.TLabel`
- test that the empty-state message is shown when cache folder is empty

## Testing
- `pytest -q tests/test_review_tab.py`
- `pre-commit run --files gui_components.py kyo_qa_tool_app.py tests/test_review_tab.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b43f361f8832eb003ba687ad4e7f7