### PR TITLE
Add export_to_excel test

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ python scripts/sample_job.py --input test_data.json
 
 ## Testing & Linting
 
-- Run tests:
+- All unit tests live in the `tests/` folder. Run them with:
   ```bash
   pytest --maxfail=1 --disable-warnings -q
   ```

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,34 @@
+import queue
+from pathlib import Path
+import openpyxl
+
+from processing_engine import export_to_excel
+
+
+def test_export_to_excel(tmp_path):
+    # Create a simple workbook with required headers
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append(["Number", "meta", "author"])
+    sheet.append(["123", "", ""])
+    template_path = tmp_path / "template.xlsx"
+    wb.save(template_path)
+
+    results = [
+        {
+            "filename": "123.pdf",
+            "models": "Model1",
+            "author": "John Doe",
+            "status": "Pass",
+        }
+    ]
+
+    output_path = export_to_excel(results, template_path, queue.Queue())
+
+    assert output_path is not None
+    assert Path(output_path).exists()
+
+    out_wb = openpyxl.load_workbook(output_path)
+    out_sheet = out_wb.active
+    assert out_sheet.cell(row=2, column=2).value == "Model1"
+    assert out_sheet.cell(row=2, column=3).value == "John Doe"


### PR DESCRIPTION
## Summary
- create tests folder with export_to_excel unit test
- note tests directory in README

## Testing
- `black tests/test_engine.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_686b4e525bec832eb204de06b59886cf