### PR TITLE
Fix duplicate pause/resume methods

### DIFF
--- a/kyo_qa_tool_app.py
+++ b/kyo_qa_tool_app.py
@@ -203,7 +203,6 @@ class KyoQAToolApp(tk.Tk):
         if path:
             self.selected_excel.set(path)
 
-
     def browse_harvest_file(self):
         path = filedialog.askopenfilename(
             title="Select PDF File", filetypes=[("PDF Files", "*.pdf")]
@@ -382,14 +381,6 @@ class KyoQAToolApp(tk.Tk):
         except Exception as e:  # pragma: no cover - just log
             logger.error(f"Manual export failed: {e}", exc_info=True)
             messagebox.showerror("Export Error", str(e))
-
-    def pause_processing(self):
-        self.pause_event.set()
-        self.status_current_file.set("Processing paused")
-
-    def resume_processing(self):
-        self.pause_event.clear()
-        self.status_current_file.set("Resuming...")
 
     def open_review_for_selected_file(self):
         selection = self.review_tree.selection()

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -3,42 +3,66 @@ import types
 import threading
 import unittest
 from types import SimpleNamespace
+from pathlib import Path
 
 # Stub heavy dependencies before importing the app module
-for name in ['openpyxl', 'PIL', 'PIL.Image', 'PyMuPDF', 'fitz', 'pytesseract', 'cv2', 'Pillow']:
+for name in [
+    "openpyxl",
+    "PIL",
+    "PIL.Image",
+    "PyMuPDF",
+    "fitz",
+    "pytesseract",
+    "cv2",
+    "Pillow",
+]:
     sys.modules.setdefault(name, types.ModuleType(name))
+
 
 class DummyTk(types.ModuleType):
     class Tk:
         def __init__(self, *a, **k):
             pass
+
     class Toplevel:
         pass
+
     class StringVar:
         def __init__(self, value=""):
             self.value = value
+
         def set(self, value):
             self.value = value
+
         def get(self):
             return self.value
+
     IntVar = StringVar
 
-sys.modules.setdefault('tkinter', DummyTk('tkinter'))
-sys.modules.setdefault('tkinter.ttk', types.ModuleType('tkinter.ttk'))
-sys.modules.setdefault('tkinter.filedialog', types.ModuleType('tkinter.filedialog'))
-sys.modules.setdefault('tkinter.messagebox', types.ModuleType('tkinter.messagebox'))
+
+sys.modules.setdefault("tkinter", DummyTk("tkinter"))
+sys.modules.setdefault("tkinter.ttk", types.ModuleType("tkinter.ttk"))
+sys.modules.setdefault("tkinter.filedialog", types.ModuleType("tkinter.filedialog"))
+sys.modules.setdefault("tkinter.messagebox", types.ModuleType("tkinter.messagebox"))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from kyo_qa_tool_app import KyoQAToolApp
+
 
 class DummyVar:
     def __init__(self):
         self.value = ""
+
     def set(self, value):
         self.value = value
 
+
 class PauseResumeTest(unittest.TestCase):
     def test_pause_and_resume(self):
-        dummy = SimpleNamespace(pause_event=threading.Event(), status_current_file=DummyVar())
+        dummy = SimpleNamespace(
+            pause_event=threading.Event(), status_current_file=DummyVar()
+        )
         KyoQAToolApp.pause_processing(dummy)
         self.assertTrue(dummy.pause_event.is_set())
         self.assertEqual(dummy.status_current_file.value, "Processing paused")
@@ -46,5 +70,22 @@ class PauseResumeTest(unittest.TestCase):
         self.assertFalse(dummy.pause_event.is_set())
         self.assertEqual(dummy.status_current_file.value, "Resuming...")
 
-if __name__ == '__main__':
+    def test_idempotent_calls(self):
+        dummy = SimpleNamespace(
+            pause_event=threading.Event(), status_current_file=DummyVar()
+        )
+        KyoQAToolApp.pause_processing(dummy)
+        initial_status = dummy.status_current_file.value
+        KyoQAToolApp.pause_processing(dummy)
+        self.assertTrue(dummy.pause_event.is_set())
+        self.assertEqual(dummy.status_current_file.value, initial_status)
+
+        KyoQAToolApp.resume_processing(dummy)
+        initial_status = dummy.status_current_file.value
+        KyoQAToolApp.resume_processing(dummy)
+        self.assertFalse(dummy.pause_event.is_set())
+        self.assertEqual(dummy.status_current_file.value, initial_status)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- remove duplicate `pause_processing` and `resume_processing` methods in `kyo_qa_tool_app.py`
- update `test_pause_resume` with path setup and add idempotency checks

## Testing
- `pytest tests/test_pause_resume.py`

------
https://chatgpt.com/codex/tasks/task_e_6873320a4a88832e8edd990d94e80538