### PR TITLE
Add shutil import and compile test

### DIFF
--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -4,6 +4,7 @@
 
 import fitz  # PyMuPDF
 import os
+import shutil
 from pathlib import Path
 import logging
 from logging_config import configure_logging

--- a/tests/test_ocr_utils_compile.py
+++ b/tests/test_ocr_utils_compile.py
@@ -1,0 +1,7 @@
+import py_compile
+from pathlib import Path
+
+
+def test_ocr_utils_py_compile():
+    target = Path(__file__).resolve().parents[1] / "ocr_utils.py"
+    py_compile.compile(str(target), doraise=True)


### PR DESCRIPTION
## Summary
- add missing `shutil` import in `ocr_utils`
- ensure `ocr_utils.py` compiles via new unit test

## Testing
- `python -m py_compile ocr_utils.py tests/test_ocr_utils_compile.py`
- ❌ `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68733208556c832ea5314d90cf236398