### PR TITLE
Fix Excel export row mapping

### DIFF
--- a/processing_engine.py
+++ b/processing_engine.py
@@ -189,7 +189,10 @@ def export_to_excel(results, excel_path, progress_queue) -> Path | None:
         if not author_col_idx:
             raise ValueError(f"Could not find the author column. Looked for: {possible_author_cols}")
 
-        filename_to_row = {cell.value: row for row, cell in enumerate(sheet.iter_cols(min_col=filename_col_idx, max_col=filename_col_idx, min_row=2), 2)}
+        filename_to_row = {
+            row[filename_col_idx - 1].value: idx
+            for idx, row in enumerate(sheet.iter_rows(min_row=2), start=2)
+        }
 
         for result in results:
             if result['status'] == 'Fail':

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -32,3 +32,37 @@ def test_export_to_excel(tmp_path):
     out_sheet = out_wb.active
     assert out_sheet.cell(row=2, column=2).value == "Model1"
     assert out_sheet.cell(row=2, column=3).value == "John Doe"
+
+
+def test_export_to_excel_multiple_rows(tmp_path):
+    """Ensure multiple rows are mapped correctly."""
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append(["Number", "meta", "author"])
+    sheet.append(["123", "", ""])
+    sheet.append(["456", "", ""])
+    template_path = tmp_path / "template.xlsx"
+    wb.save(template_path)
+
+    results = [
+        {
+            "filename": "123.pdf",
+            "models": "Model1",
+            "author": "John Doe",
+            "status": "Pass",
+        },
+        {
+            "filename": "456.pdf",
+            "models": "Model2",
+            "author": "Jane Roe",
+            "status": "Pass",
+        },
+    ]
+
+    output_path = export_to_excel(results, template_path, queue.Queue())
+
+    out_wb = openpyxl.load_workbook(output_path)
+    out_sheet = out_wb.active
+    assert out_sheet.cell(row=2, column=2).value == "Model1"
+    assert out_sheet.cell(row=3, column=2).value == "Model2"
+


### PR DESCRIPTION
## Summary
- iterate over worksheet rows when building filename lookup
- add regression test for multiple-row Excel export

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68733eaec20c832e9d28d27f75d1ae3f