### PR TITLE
Remove unused Path import

### DIFF
--- a/data_harvesters.py
+++ b/data_harvesters.py
@@ -3,7 +3,6 @@ import re
 import importlib
 import logging
 from logging_config import configure_logging
-from pathlib import Path
 
 # Configure logging
 logger = configure_logging("harvesters")

--- a/tests/test_data_harvesters_compile.py
+++ b/tests/test_data_harvesters_compile.py
@@ -1,0 +1,5 @@
+import py_compile
+
+
+def test_data_harvesters_py_compile():
+    py_compile.compile("data_harvesters.py", doraise=True)


### PR DESCRIPTION
## Summary
- clean up unused Path import in `data_harvesters`
- add a compile test for the module

## Testing
- `pip install flake8` *(fails: Tunnel connection failed 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68733e32080c832eacc785f122128c22