### PR TITLE
Add QA number harvesting and caching

### DIFF
--- a/data_harvesters.py
+++ b/data_harvesters.py
@@ -48,9 +48,8 @@ def harvest_models(text: str, filename: str) -> list:
     if not text:
         return []
 
-    model_patterns = get_combined_patterns("MODEL_PATTERNS", DEFAULT_MODEL_PATTERNS)
-    qa_patterns = get_combined_patterns("QA_NUMBER_PATTERNS", DEFAULT_QA_PATTERNS)
-    all_search_patterns = model_patterns + qa_patterns
+    model_patterns = get_combined_patterns('MODEL_PATTERNS', DEFAULT_MODEL_PATTERNS)
+    all_search_patterns = model_patterns
 
     found = set()
     for pattern in all_search_patterns:
@@ -71,6 +70,26 @@ def harvest_models(text: str, filename: str) -> list:
         standardized_found.add(item)
 
     return sorted(list(standardized_found))
+
+
+def harvest_qa_numbers(text: str) -> list:
+    """Extract QA numbers using combined default and custom patterns."""
+    if not text:
+        return []
+
+    qa_patterns = get_combined_patterns('QA_NUMBER_PATTERNS', DEFAULT_QA_PATTERNS)
+
+    found = set()
+    for pattern in qa_patterns:
+        try:
+            matches = re.findall(pattern, text, re.IGNORECASE)
+            for match in matches:
+                if not any(ex in match for ex in EXCLUSION_PATTERNS):
+                    found.add(match.strip())
+        except re.error as e:
+            logger.warning(f"Invalid regex pattern skipped: '{pattern}'. Error: {e}")
+
+    return sorted(found)
 
 
 def harvest_author(text: str) -> str:
@@ -105,9 +124,11 @@ def harvest_all_data(text: str, filename: str) -> dict:
     try:
         models = harvest_models(text, filename)
         models_str = ", ".join(models) if models else "Not Found"
+        qa_nums = harvest_qa_numbers(text)
+        qa_nums_str = ", ".join(qa_nums) if qa_nums else ""
         author_str = harvest_author(text)
 
-        return {"models": models_str, "author": author_str}
+        return {"models": models_str, "qa_numbers": qa_nums_str, "author": author_str}
     except Exception as e:
         logger.error(f"Critical error during data harvesting for {filename}: {e}", exc_info=True)
-        return {"models": "Error: Harvesting Failed", "author": ""}
+        return {"models": "Error: Harvesting Failed", "qa_numbers": "", "author": ""}

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -154,7 +154,15 @@ def process_single_pdf(pdf_path, progress_queue, ignore_cache=False):
 
     except Exception as e:
         logger.error(f"Failed to process {filename}: {e}", exc_info=True)
-        result = {"filename": filename, "models": f"Error: {e}", "author": "", "status": "Fail", "ocr_needed": False, "review_info": None}
+        result = {
+            "filename": filename,
+            "models": f"Error: {e}",
+            "qa_numbers": "",
+            "author": "",
+            "status": "Fail",
+            "ocr_needed": False,
+            "review_info": None,
+        }
         progress_queue.put({"type": "update_counts", "status": "Fail"})
 
     try:

--- a/tests/test_harvest_qa_numbers.py
+++ b/tests/test_harvest_qa_numbers.py
@@ -11,4 +11,6 @@ def test_harvest_qa_numbers_simple():
     qa = dh.harvest_qa_numbers(text)
     assert "QA123" in qa and "SB-456" in qa
     data = dh.harvest_all_data(text, "sample.pdf")
-    assert "QA123" in data.get("qa_numbers", "")
+    expected_qa_numbers = ["QA123", "SB-456"]
+    actual_qa_numbers = data.get("qa_numbers", "").split(", ")
+    assert actual_qa_numbers == expected_qa_numbers

--- a/tests/test_harvest_qa_numbers.py
+++ b/tests/test_harvest_qa_numbers.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import data_harvesters as dh
+
+
+def test_harvest_qa_numbers_simple():
+    text = "Model TASKalfa 300i referenced QA123 and SB-456"
+    qa = dh.harvest_qa_numbers(text)
+    assert "QA123" in qa and "SB-456" in qa
+    data = dh.harvest_all_data(text, "sample.pdf")
+    assert "QA123" in data.get("qa_numbers", "")


### PR DESCRIPTION
## Summary
- harvest QA numbers separately using `DEFAULT_QA_PATTERNS`
- include `qa_numbers` in aggregated harvesting results
- keep cached results compatible with new field
- test extraction of QA numbers

## Testing
- `mypy data_harvesters.py processing_engine.py tests/test_harvest_qa_numbers.py --ignore-missing-imports` *(fails: logging_utils.py need type annotations)*
- `pytest tests/test_harvest_qa_numbers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68733e8036c8832e97becd2a43b786b4