### PR TITLE
Fix Excel export row matching

### DIFF
--- a/processing_engine.py
+++ b/processing_engine.py
@@ -189,7 +189,14 @@ def export_to_excel(results, excel_path, progress_queue) -> Path | None:
         if not author_col_idx:
             raise ValueError(f"Could not find the author column. Looked for: {possible_author_cols}")
 
-        filename_to_row = {cell.value: row for row, cell in enumerate(sheet.iter_cols(min_col=filename_col_idx, max_col=filename_col_idx, min_row=2), 2)}
+        filename_to_row = {}
+        for row in sheet.iter_rows(
+            min_row=2,
+            min_col=filename_col_idx,
+            max_col=filename_col_idx,
+        ):
+            cell = row[0]
+            filename_to_row[cell.value] = cell.row
 
         for result in results:
             if result['status'] == 'Fail':
@@ -203,6 +210,9 @@ def export_to_excel(results, excel_path, progress_queue) -> Path | None:
                     sheet.cell(row=row_num, column=meta_col_idx).value = result['models']
                 if not sheet.cell(row=row_num, column=author_col_idx).value:
                     sheet.cell(row=row_num, column=author_col_idx).value = result.get('author', '')
+            else:
+                logger.warning(f"Filename not found in Excel: {kb_number}")
+                progress_queue.put({"type": "log", "tag": "warning", "msg": f"No Excel match for {kb_number}"})
 
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         output_filename = f"{excel_path.stem}_processed_{timestamp}{excel_path.suffix}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -32,3 +32,27 @@ def test_export_to_excel(tmp_path):
     out_sheet = out_wb.active
     assert out_sheet.cell(row=2, column=2).value == "Model1"
     assert out_sheet.cell(row=2, column=3).value == "John Doe"
+
+
+def test_export_to_excel_warns_on_missing_file(tmp_path):
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append(["Number", "meta", "author"])
+    sheet.append(["123", "", ""])
+    template_path = tmp_path / "template.xlsx"
+    wb.save(template_path)
+
+    results = [
+        {
+            "filename": "456.pdf",
+            "models": "ModelX",
+            "author": "Jane",
+            "status": "Pass",
+        }
+    ]
+
+    q = queue.Queue()
+    export_to_excel(results, template_path, q)
+
+    logs = [q.get() for _ in range(q.qsize())]
+    assert any(item.get("tag") == "warning" for item in logs)


### PR DESCRIPTION
## Summary
- map article numbers to rows with iteration instead of comprehension
- warn via logger and progress queue when a PDF's article number isn't in the Excel sheet
- test that warnings emit for unmatched filenames

## Testing
- `black tests/test_engine.py` *(pass)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*


------
https://chatgpt.com/codex/tasks/task_e_68733e8d0164832e88d242abd55c0e68