### PR TITLE
Add QA numbers export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ KYO_QA_ServiceNow_Knowledge_Tool_v26.0.0/\
 - **Modular & Logged**: Comprehensive logging to `/logs/` and `PDF_TXT/needs_review` for review.
 - **UI**: Bright, Kyocera-branded Tkinter UI with progress bars, color-coded logs, and detailed processing feedback.
 - **Excel**: Clones input Excel, updates only blank "Meta" cells with model numbers.
+  If your template includes a "QA Numbers" column, those values are placed there;
+  otherwise they are added to the Meta text.
 
 ## Setup Steps
 
@@ -132,11 +134,14 @@ KYO_QA_ServiceNow_Knowledge_Tool_v26.0.0/\
 ## Usage
 
 1. Launch the tool via `START.bat` or `python run.py`.
-2. Select an Excel file with a "Meta" column (case-insensitive).
+2. Select an Excel file with a "Meta" column (case-insensitive). You may also
+   include an optional **"QA Numbers"** column to keep QA identifiers separate.
 3. Select a folder or PDF files (`.pdf` or `.zip`) containing Kyocera QA/service documents.
 4. Click "Start Processing" to:
    - Extract model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`), QA numbers, and metadata.
-   - Update blank "Meta" cells in a cloned Excel file.
+   - Update blank "Meta" cells in a cloned Excel file. If a "QA Numbers" column
+     exists, QA numbers will be written there; otherwise they are appended to the
+     Meta field.
    - Save text files for failed or incomplete extractions in `PDF_TXT/needs_review`.
 5. Review output in `/output/cloned_<excel>.xlsx` and logs in `/logs/` or `PDF_TXT/needs_review`.
 

--- a/config.py
+++ b/config.py
@@ -42,6 +42,7 @@ STATUS_COLUMN_NAME = "Validation Status"
 DESCRIPTION_COLUMN_NAME = "description"
 META_COLUMN_NAME = "meta"
 AUTHOR_COLUMN_NAME = "author"
+QA_NUMBERS_COLUMN_NAME = "QA Numbers"
 
 
 # --- Functions for GUI Configuration ---

--- a/processing_engine.py
+++ b/processing_engine.py
@@ -13,7 +13,13 @@ from logging_config import configure_logging
 from data_harvesters import harvest_all_data
 from ocr_utils import extract_text_from_pdf, _is_ocr_needed
 from file_utils import is_file_locked
-from config import CACHE_DIR, PDF_TXT_DIR, META_COLUMN_NAME, AUTHOR_COLUMN_NAME
+from config import (
+    CACHE_DIR,
+    PDF_TXT_DIR,
+    META_COLUMN_NAME,
+    AUTHOR_COLUMN_NAME,
+    QA_NUMBERS_COLUMN_NAME,
+)
 from processing_helpers import fetch_data, parse_data, export_results
 
 logger = configure_logging("processing_engine")
@@ -177,10 +183,12 @@ def export_to_excel(results, excel_path, progress_queue) -> Path | None:
         possible_filename_cols = ['Number', 'number', 'article number', 'kb number', 'kb_number']
         possible_meta_cols = [META_COLUMN_NAME, 'meta', 'keywords']
         possible_author_cols = [AUTHOR_COLUMN_NAME, 'author']
+        possible_qa_cols = [QA_NUMBERS_COLUMN_NAME, 'qa numbers', 'qa_numbers', 'qa']
 
         filename_col_idx = find_column_index(header, possible_filename_cols)
         meta_col_idx = find_column_index(header, possible_meta_cols)
         author_col_idx = find_column_index(header, possible_author_cols)
+        qa_col_idx = find_column_index(header, possible_qa_cols)
 
         if not filename_col_idx:
             raise ValueError(f"Could not find an article number column. Looked for: {possible_filename_cols}")
@@ -188,20 +196,43 @@ def export_to_excel(results, excel_path, progress_queue) -> Path | None:
             raise ValueError(f"Could not find the meta/keywords column. Looked for: {possible_meta_cols}")
         if not author_col_idx:
             raise ValueError(f"Could not find the author column. Looked for: {possible_author_cols}")
+        # QA column is optional; qa_col_idx may be None
 
         filename_to_row = {cell.value: row for row, cell in enumerate(sheet.iter_cols(min_col=filename_col_idx, max_col=filename_col_idx, min_row=2), 2)}
 
         for result in results:
             if result['status'] == 'Fail':
                 continue
-            
+
             kb_number = Path(result['filename']).stem
             row_num = filename_to_row.get(kb_number)
 
             if row_num:
-                if not sheet.cell(row=row_num, column=meta_col_idx).value:
-                    sheet.cell(row=row_num, column=meta_col_idx).value = result['models']
-                if not sheet.cell(row=row_num, column=author_col_idx).value:
+                meta_value = sheet.cell(row=row_num, column=meta_col_idx).value
+                author_value = sheet.cell(row=row_num, column=author_col_idx).value
+
+                if not meta_value:
+                    models_val = result['models']
+                    if result.get('qa_numbers') and qa_col_idx is None:
+                        qa_str = (
+                            ", ".join(result['qa_numbers'])
+                            if isinstance(result['qa_numbers'], list)
+                            else str(result['qa_numbers'])
+                        )
+                        models_val = f"{models_val}, {qa_str}"
+                    sheet.cell(row=row_num, column=meta_col_idx).value = models_val
+
+                if qa_col_idx and result.get('qa_numbers'):
+                    qa_cell_val = sheet.cell(row=row_num, column=qa_col_idx).value
+                    if not qa_cell_val:
+                        qa_str = (
+                            ", ".join(result['qa_numbers'])
+                            if isinstance(result['qa_numbers'], list)
+                            else str(result['qa_numbers'])
+                        )
+                        sheet.cell(row=row_num, column=qa_col_idx).value = qa_str
+
+                if not author_value:
                     sheet.cell(row=row_num, column=author_col_idx).value = result.get('author', '')
 
         timestamp = time.strftime("%Y%m%d-%H%M%S")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,7 +6,6 @@ from processing_engine import export_to_excel
 
 
 def test_export_to_excel(tmp_path):
-    # Create a simple workbook with required headers
     wb = openpyxl.Workbook()
     sheet = wb.active
     sheet.append(["Number", "meta", "author"])
@@ -19,6 +18,36 @@ def test_export_to_excel(tmp_path):
             "filename": "123.pdf",
             "models": "Model1",
             "author": "John Doe",
+            "qa_numbers": ["QA-1"],
+            "status": "Pass",
+        }
+    ]
+
+    output_path = export_to_excel(results, template_path, queue.Queue())
+
+    assert output_path is not None
+    assert Path(output_path).exists()
+
+    out_wb = openpyxl.load_workbook(output_path)
+    out_sheet = out_wb.active
+    assert out_sheet.cell(row=2, column=2).value == "Model1, QA-1"
+    assert out_sheet.cell(row=2, column=3).value == "John Doe"
+
+
+def test_export_to_excel_with_qa_column(tmp_path):
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append(["Number", "meta", "author", "QA Numbers"])
+    sheet.append(["123", "", "", ""])
+    template_path = tmp_path / "template.xlsx"
+    wb.save(template_path)
+
+    results = [
+        {
+            "filename": "123.pdf",
+            "models": "Model1",
+            "author": "John Doe",
+            "qa_numbers": ["QA-1", "QA-2"],
             "status": "Pass",
         }
     ]
@@ -32,3 +61,4 @@ def test_export_to_excel(tmp_path):
     out_sheet = out_wb.active
     assert out_sheet.cell(row=2, column=2).value == "Model1"
     assert out_sheet.cell(row=2, column=3).value == "John Doe"
+    assert out_sheet.cell(row=2, column=4).value == "QA-1, QA-2"


### PR DESCRIPTION
## Summary
- handle QA numbers when exporting Excel results
- document optional QA Numbers column in README
- define `QA_NUMBERS_COLUMN_NAME` constant
- test QA numbers export logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*
- `pre-commit run --files README.md config.py processing_engine.py tests/test_engine.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68733e81e070832e99fdf9822273ab11