### PR TITLE
Improve row lookup in export_to_excel

### DIFF
--- a/processing_engine.py
+++ b/processing_engine.py
@@ -189,7 +189,14 @@ def export_to_excel(results, excel_path, progress_queue) -> Path | None:
         if not author_col_idx:
             raise ValueError(f"Could not find the author column. Looked for: {possible_author_cols}")
 
-        filename_to_row = {cell.value: row for row, cell in enumerate(sheet.iter_cols(min_col=filename_col_idx, max_col=filename_col_idx, min_row=2), 2)}
+        filename_to_row = {
+            row[0].value: row[0].row
+            for row in sheet.iter_rows(
+                min_row=2,
+                min_col=filename_col_idx,
+                max_col=filename_col_idx,
+            )
+        }
 
         for result in results:
             if result['status'] == 'Fail':
@@ -203,6 +210,10 @@ def export_to_excel(results, excel_path, progress_queue) -> Path | None:
                     sheet.cell(row=row_num, column=meta_col_idx).value = result['models']
                 if not sheet.cell(row=row_num, column=author_col_idx).value:
                     sheet.cell(row=row_num, column=author_col_idx).value = result.get('author', '')
+            else:
+                warning_msg = f"No matching row for {kb_number}"
+                logger.warning(warning_msg)
+                progress_queue.put({"type": "log", "tag": "warning", "msg": warning_msg})
 
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         output_filename = f"{excel_path.stem}_processed_{timestamp}{excel_path.suffix}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -32,3 +32,27 @@ def test_export_to_excel(tmp_path):
     out_sheet = out_wb.active
     assert out_sheet.cell(row=2, column=2).value == "Model1"
     assert out_sheet.cell(row=2, column=3).value == "John Doe"
+
+
+def test_export_to_excel_missing_row(tmp_path):
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append(["Number", "meta", "author"])
+    sheet.append(["123", "", ""])
+    template_path = tmp_path / "template.xlsx"
+    wb.save(template_path)
+
+    q = queue.Queue()
+    results = [
+        {
+            "filename": "999.pdf",
+            "models": "ModelX",
+            "author": "Jane",
+            "status": "Pass",
+        }
+    ]
+
+    export_to_excel(results, template_path, q)
+
+    warnings = [item for item in list(q.queue) if item.get("tag") == "warning"]
+    assert warnings


### PR DESCRIPTION
## Summary
- fix row mapping logic to iterate over rows instead of columns
- warn if no matching row exists for a file
- test for warning when file number is missing from worksheet

## Testing
- `python -m py_compile processing_engine.py tests/test_engine.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68733e810524832e8c6ea16159b45fbd